### PR TITLE
npm-run-all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -72,7 +72,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -82,7 +82,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -107,13 +107,31 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
     "array-unique": {
@@ -125,7 +143,7 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "arrify": {
@@ -173,7 +191,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -379,7 +397,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo2": {
@@ -493,7 +511,7 @@
     "browser-sync": {
       "version": "2.23.6",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.23.6.tgz",
-      "integrity": "sha1-7QchyS5bmMcbe/g5s5CSrJ8iBlA=",
+      "integrity": "sha512-loCO5NQKZXfBJrEvmLwF1TPSECCsPopNd29qduoysLmpw8op2lgolGMjz3oI/MjG4duzB9TfDs7k58djRSwPwg==",
       "dev": true,
       "requires": {
         "browser-sync-ui": "1.0.1",
@@ -528,7 +546,7 @@
     "browser-sync-ui": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-      "integrity": "sha1-l0BSeybR16ziWazAx55bXjfQ/fI=",
+      "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -648,6 +666,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
@@ -802,7 +835,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -813,6 +846,16 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -851,6 +894,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "easy-extender": {
@@ -956,7 +1005,7 @@
     "engine.io-parser": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha1-TA9M/3mq7su9z96maoI8YIVAkZY=",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
@@ -973,6 +1022,30 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-html": {
@@ -998,6 +1071,21 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -1118,6 +1206,12 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1150,6 +1244,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -1164,7 +1264,7 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -1176,7 +1276,7 @@
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2089,6 +2189,12 @@
         "rimraf": "2.6.2"
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2161,7 +2267,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -2194,7 +2300,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globule": {
@@ -2230,6 +2336,15 @@
         "har-schema": "1.0.5"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2260,6 +2375,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-unicode": {
@@ -2307,7 +2428,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "http-errors": {
@@ -2418,7 +2539,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -2429,6 +2550,18 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2508,7 +2641,7 @@
     "is-number-like": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
         "lodash.isfinite": "3.3.2"
@@ -2530,6 +2663,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -2599,6 +2747,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -2696,7 +2850,7 @@
     "limiter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
-      "integrity": "sha1-Ip2AVYkcixGvng7lIA6OCbs9y+s=",
+      "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw==",
       "dev": true
     },
     "load-json-file": {
@@ -2807,7 +2961,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -2818,6 +2972,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
     "meow": {
@@ -2891,7 +3057,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -2938,6 +3104,12 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "dev": true
+    },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
@@ -2970,7 +3142,7 @@
     "node-sass": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-      "integrity": "sha1-k2Z3i6FGnrAUOKnoWS9CYry2eU4=",
+      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -3066,7 +3238,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -3084,10 +3256,5249 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.1.0.tgz",
+      "integrity": "sha512-e38cCtJ0lEjLXXpc4twEfj8Xw5hDLolc2Py87ueWnUhJfZ8GA/5RVIeD+XbSr1+aVRGsRsdtLdzUNO63PvQJ1w==",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.0.2",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.5",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.6.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.2.1",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.3",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "8.1.5",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.86.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "strip-ansi": "4.0.0",
+        "tar": "4.4.1",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bin-links": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "byte-size": {
+          "version": "4.0.3",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "11.0.2",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "cli-table2": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "wcwidth": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
+              "dependencies": {
+                "defaults": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
+                  "dependencies": {
+                    "clone": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          },
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "bundled": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "bundled": true
+            }
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "figgy-pudding": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
+          },
+          "dependencies": {
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "2.0.8"
+          },
+          "dependencies": {
+            "cidr-regex": {
+              "version": "2.0.8",
+              "bundled": true,
+              "requires": {
+                "ip-regex": "2.1.0"
+              },
+              "dependencies": {
+                "ip-regex": {
+                  "version": "2.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "libcipm": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "npm-lifecycle": "2.0.3",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
+          },
+          "dependencies": {
+            "npm-logical-tree": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "pacote": {
+              "version": "7.6.1",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "get-stream": "3.0.0",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "2.6.0",
+                "minimatch": "3.0.4",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.1.0",
+                "npm-packlist": "1.1.10",
+                "npm-pick-manifest": "2.1.0",
+                "osenv": "0.1.5",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "5.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.2",
+                "semver": "5.5.0",
+                "ssri": "5.3.0",
+                "tar": "4.4.1",
+                "unique-filename": "1.1.0",
+                "which": "1.3.0"
+              },
+              "dependencies": {
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "get-stream": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "make-fetch-happen": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.3.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mississippi": {
+                      "version": "1.3.1",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          },
+                          "dependencies": {
+                            "pump": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
+                              }
+                            }
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "1.1.10",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "1.1.15",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.11"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
+          },
+          "dependencies": {
+            "npm-registry-fetch": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
+              },
+              "dependencies": {
+                "make-fetch-happen": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "11.0.2",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "3.0.0",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "4.0.0",
+                    "ssri": "6.0.0"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.8.1",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.21"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.21",
+                              "bundled": true,
+                              "requires": {
+                                "safer-buffer": "2.1.2"
+                              },
+                              "dependencies": {
+                                "safer-buffer": {
+                                  "version": "2.1.2",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "promise-retry": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
+                      },
+                      "dependencies": {
+                        "err-code": {
+                          "version": "1.1.2",
+                          "bundled": true
+                        },
+                        "retry": {
+                          "version": "0.10.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.2",
+                        "socks": "2.1.6"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.2",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.2.4"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.2.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "2.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "4.0.1"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "libnpx": {
+          "version": "10.2.0",
+          "bundled": true,
+          "requires": {
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  },
+                  "dependencies": {
+                    "locate-path": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                      },
+                      "dependencies": {
+                        "p-locate": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-limit": "1.2.0"
+                          },
+                          "dependencies": {
+                            "p-limit": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-try": "1.0.0"
+                              },
+                              "dependencies": {
+                                "p-try": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-exists": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.3",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "lcid": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "invert-kv": "1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "mem": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "mimic-fn": "1.2.0"
+                      },
+                      "dependencies": {
+                        "mimic-fn": {
+                          "version": "1.2.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lock-verify": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "lockfile": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._createset": {
+              "version": "4.0.3",
+              "bundled": true
+            },
+            "lodash._root": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "duplexify": {
+              "version": "3.5.4",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
+            },
+            "flush-write-stream": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "from2": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "parallel-transform": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "cyclist": {
+                  "version": "0.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pump": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "pumpify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                }
+              }
+            },
+            "stream-each": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
+          },
+          "dependencies": {
+            "copy-concurrently": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+              },
+              "dependencies": {
+                "iferr": {
+                  "version": "0.1.5",
+                  "bundled": true
+                }
+              }
+            },
+            "run-queue": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0"
+              }
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.6.2",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.86.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1"
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          },
+          "dependencies": {
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
+              "dependencies": {
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "cli-table2": "0.2.0",
+            "console-control-strings": "1.1.0"
+          },
+          "dependencies": {
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-package-arg": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          },
+          "dependencies": {
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "3.0.4"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "npm-profile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
+          },
+          "dependencies": {
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-registry-client": {
+          "version": "8.5.1",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.86.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "ssri": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            }
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "figgy-pudding": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "cacache": {
+                  "version": "10.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.3",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
+                  },
+                  "dependencies": {
+                    "mississippi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                      },
+                      "dependencies": {
+                        "concat-stream": {
+                          "version": "1.6.2",
+                          "bundled": true,
+                          "requires": {
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
+                          },
+                          "dependencies": {
+                            "buffer-from": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "typedarray": {
+                              "version": "0.0.6",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexify": {
+                          "version": "3.5.4",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.4.1",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        },
+                        "flush-write-stream": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "from2": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "requires": {
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "parallel-transform": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
+                          },
+                          "dependencies": {
+                            "cyclist": {
+                              "version": "0.2.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        },
+                        "pumpify": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
+                          }
+                        },
+                        "stream-each": {
+                          "version": "1.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
+                          },
+                          "dependencies": {
+                            "stream-shift": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "2.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
+                          },
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y18n": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.21"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.21",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ssri": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              },
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "opener": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "pacote": {
+          "version": "8.1.5",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cacache": "11.0.2",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.1",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "11.0.2",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "4.0.1",
+                "ssri": "6.0.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.23"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.23",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "2.2.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "2.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "4.0.1"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "minipass": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "yallist": {
+                  "version": "3.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "promise-retry": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
+              "dependencies": {
+                "err-code": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "retry": {
+                  "version": "0.10.1",
+                  "bundled": true
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
+          },
+          "dependencies": {
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "strict-uri-encode": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            }
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
+          "dependencies": {
+            "util-extend": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
+          },
+          "dependencies": {
+            "json-parse-better-errors": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
+        },
+        "request": {
+          "version": "2.86.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.7.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "5.5.2",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "bundled": true
+                    },
+                    "fast-deep-equal": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "fast-json-stable-stringify": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "4.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                },
+                "cryptiles": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.1"
+                      }
+                    }
+                  }
+                },
+                "hoek": {
+                  "version": "4.2.1",
+                  "bundled": true
+                },
+                "sntp": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.3.0",
+                      "bundled": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "verror": {
+                      "version": "1.10.0",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.18",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.33.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.33.0",
+                  "bundled": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.4",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            }
+          }
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "sha": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-iterate": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "ssri": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.3.1"
+              }
+            },
+            "minipass": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.3.1"
+              }
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.4.1",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "term-size": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.3",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "2.4.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.1"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.1",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "5.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "3.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "configstore": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.2.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "make-dir": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "3.0.0"
+                  },
+                  "dependencies": {
+                    "pify": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "unique-string": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crypto-random-string": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "import-lazy": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-ci": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ci-info": "1.1.3"
+              },
+              "dependencies": {
+                "ci-info": {
+                  "version": "1.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.5"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "latest-version": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.2",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "6.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.2",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexer3": {
+                          "version": "0.1.4",
+                          "bundled": true
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "timed-out": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        },
+                        "unzip-response": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.7",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.5.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.7"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.5.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.5.0"
+              }
+            },
+            "xdg-basedir": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          },
+          "dependencies": {
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-exceptions": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
+          "dependencies": {
+            "builtins": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.7"
+          },
+          "dependencies": {
+            "errno": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "prr": "1.0.1"
+              },
+              "dependencies": {
+                "prr": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        }
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+      "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "memorystream": "0.3.1",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "read-pkg": "3.0.0",
+        "shell-quote": "1.6.1",
+        "string.prototype.padend": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -3118,6 +8529,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object-path": {
@@ -3157,7 +8574,7 @@
     "onchange": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/onchange/-/onchange-3.3.0.tgz",
-      "integrity": "sha1-2pJQsWI+AZ8PcdyK/VYnNAZHK2E=",
+      "integrity": "sha512-0ZQIdGkhG8Y+r8BIcjjDV93X59KkZ4Cc+ZxA9N+wA/3vm1cvd8/f2NXlCPCZpowSd78eCERk29dtuS8+X97MLg==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -3310,6 +8727,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -3319,6 +8742,15 @@
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
       }
     },
     "performance-now": {
@@ -3367,7 +8799,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -3375,6 +8807,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3397,7 +8838,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -3502,13 +8943,13 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -3619,7 +9060,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -3634,7 +9075,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "sass-graph": {
@@ -3711,7 +9152,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "send": {
@@ -3875,6 +9316,18 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -3973,7 +9426,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
@@ -3999,6 +9452,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "sshpk": {
       "version": "1.13.1",
@@ -4039,6 +9501,15 @@
         "readable-stream": "2.3.3"
       }
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
     "stream-throttle": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
@@ -4060,10 +9531,21 @@
         "strip-ansi": "3.0.1"
       }
     },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -4134,6 +9616,12 @@
         "object-path": "0.9.2"
       }
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
@@ -4158,7 +9646,7 @@
     "tree-kill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-      "integrity": "sha1-WEZ4Yje0I5AU8F2xVrZDIS1MbzY=",
+      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
       "dev": true
     },
     "trim-newlines": {
@@ -4271,7 +9759,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "universalify": {
@@ -4307,7 +9795,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ=",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
     "uws": {
@@ -4358,12 +9846,12 @@
     "what-input": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/what-input/-/what-input-4.3.1.tgz",
-      "integrity": "sha1-uOp1VLodkXGIfExq3fKBhf7D0x0="
+      "integrity": "sha512-7KD71RWNRWI9M08shZ8+n/2UjO5amwsG9PMSXWz0iIlH8H2DVbHE8Z2tW1RqQa0kIwdeqdUIffFz7crDfkcbAw=="
     },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -4378,7 +9866,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -4415,7 +9903,7 @@
     "ws": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
         "async-limiter": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,8 @@
     "env": "development"
   },
   "scripts": {
-    "content": "bundle exec middleman contentful",
-    "build": "npm run styles & npm run uglify & npm run images & npm run fonts",
     "build:production": "npm run build --datica.com:env=production",
     "browsersync": "browser-sync start --config ./bs-config.js",
-    "serve": "parallelshell 'npm run browsersync' 'npm run watch:css' 'npm run watch:js' 'npm run watch:images' 'npm run watch:fonts'",
     "watch:css": "onchange 'source/assets/scss/**/*.scss' -- npm run styles",
     "watch:js": "onchange 'source/assets/js/**/*.js' -- npm run uglify",
     "watch:images": "onchange 'source/assets/{img,icons}/**/*' -- npm run images",
@@ -23,7 +20,10 @@
     "images": "npm run images:img & npm run images:icons",
     "images:img": "mkdir -p .tmp/public/img && cp -r source/assets/img/* .tmp/public/img",
     "images:icons": "mkdir -p .tmp/public/icons && cp -r source/assets/icons/* .tmp/public/icons",
-    "fonts": "mkdir -p .tmp/public/fonts && cp -r source/assets/fonts/* .tmp/public/fonts"
+    "fonts": "mkdir -p .tmp/public/fonts && cp -r source/assets/fonts/* .tmp/public/fonts",
+    "content": "bundle exec middleman contentful",
+    "build": "npm run styles & npm run uglify & npm run images & npm run fonts",
+    "serve": "npm-run-all browsersync watch:** --parallel"
   },
   "repository": {
     "type": "git",
@@ -34,9 +34,10 @@
   "dependencies": {
     "animejs": "^1.1.3",
     "foundation-sites": "6.4.3",
+    "jquery": "~3.2.1",
     "motion-ui": "~1.2.3",
-    "svg-injector": "^1.1.3",
-    "jquery": "~3.2.1"
+    "npm": "^6.1.0",
+    "svg-injector": "^1.1.3"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
@@ -44,6 +45,7 @@
     "glob": "^7.1.1",
     "hoek": "^5.0.3",
     "node-sass": "^4.5.0",
+    "npm-run-all": "^4.1.3",
     "onchange": "^3.2.1",
     "parallelshell": "^2.0.0",
     "uglify-js": "^2.8.0"


### PR DESCRIPTION
Moving from `parallelshell` (which is deprecated) to `npm-run-all` which seems superior, and works on current node. 