### PR TITLE
Seo/ab testing

### DIFF
--- a/source/layouts/basic.erb
+++ b/source/layouts/basic.erb
@@ -5,6 +5,7 @@
         <% if current_page.data.has_key?("asset_preload") %>
             <%= current_page.data.asset_preload %>
         <% end %>
+        <%# testing this as Netlify injection %>
         <% if build? %><%= partial "partials/scripts/google-tm-head" %><% end %>
         <%# Meta tags %>
         <%= partial "partials/head/tags" %>

--- a/source/partials/scripts/_google-tm-head.erb
+++ b/source/partials/scripts/_google-tm-head.erb
@@ -1,6 +1,30 @@
 <%# Google Tag Manager, GA Optimize %>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MVXG5LZ');</script>
+<script>
+    dataLayer = [{
+        currentBranch: '{{ BRANCH }}'
+    }];
+	(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-MVXG5LZ');
+</script>
+
+<%# Google Tag Manager, GA Optimize
+<script>
+    (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+            'gtm.start': new Date().getTime(),
+            event: 'gtm.js'
+        });
+        var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src =
+            'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-MVXG5LZ');
+</script>
+ %>

--- a/source/partials/scripts/_google-tm-head.erb
+++ b/source/partials/scripts/_google-tm-head.erb
@@ -1,4 +1,4 @@
-<!-- Hiding this GTM snippet, to see if Netlify can inject the dataLayer. -->
+<!-- Hiding this GTM snippet, to see if Netlify can inject the dataLayer. Injected before end of /head, may not be high enough. -->
 <%# Google Tag Manager, GA Optimize 
 <script>
     dataLayer = [{

--- a/source/partials/scripts/_google-tm-head.erb
+++ b/source/partials/scripts/_google-tm-head.erb
@@ -1,4 +1,5 @@
-<%# Google Tag Manager, GA Optimize %>
+<!-- Hiding this GTM snippet, to see if Netlify can inject the dataLayer. -->
+<%# Google Tag Manager, GA Optimize 
 <script>
     dataLayer = [{
         currentBranch: '{{ BRANCH }}'
@@ -9,7 +10,7 @@
 	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 	})(window,document,'script','dataLayer','GTM-MVXG5LZ');
 </script>
-
+%>
 <%# Google Tag Manager, GA Optimize
 <script>
     (function(w, d, s, l, i) {


### PR DESCRIPTION
All this does is hide/omit the GTM tag script, which is now being [injected by Netlify](https://www.netlify.com/docs/split-testing/#using-netlify-snippet-injection-to-track-split-testing-information). 