### PR TITLE
Feature: Contentful Collections

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -189,13 +189,14 @@ activate :contentful do |f|
     f.access_token = '9abdf5de79abc1e1cdc2cf25f3280641fd845a2f3fd5bad8222d1b457f20ba2d'
     f.use_preview_api = false
     f.all_entries = true
-    f.client_options = { max_include_resolution_depth: 2 }
+    f.client_options = { max_include_resolution_depth: 1 }
     f.content_types = {
         academy: 'academy',
         blog: 'blog',
         caseStudy: 'caseStudy',
         cta: 'cta',
         customers: 'customers',
+        collections: 'genericCollection',
         discover: 'discover',
         events: 'events',
         featureCategories: 'featureCategories',

--- a/config.rb
+++ b/config.rb
@@ -189,7 +189,7 @@ activate :contentful do |f|
     f.access_token = '9abdf5de79abc1e1cdc2cf25f3280641fd845a2f3fd5bad8222d1b457f20ba2d'
     f.use_preview_api = false
     f.all_entries = true
-    f.client_options = { max_include_resolution_depth: 1 }
+    f.client_options = { max_include_resolution_depth: 2 }
     f.content_types = {
         academy: 'academy',
         blog: 'blog',

--- a/source/about/index.html.erb
+++ b/source/about/index.html.erb
@@ -50,7 +50,7 @@ layout: company
                         <li>Compliance moves at the speed of trust.</li>
                         <li>Transparency is how complex subjects, like HIPAA or GDPR, become easier to understand. We're trusted because we're transparent.</li>
                         <li>Healthcare application development shouldn't be harder than other industry just because of HIPAA. Doing business in the European Union shouldn't be harder because of GDPR. Compliance shouldn't block progress.</li>
-                        <li>Give back to the developer community whenever possible. Use open source tools whenever possible. Our <a href="/open-source">open source contributions <i class="fa fa-caret-right"></i></a></li>
+                        <li>Give back to the developer community whenever possible. Use open source tools whenever possible. Learn more about our <a class="link-arrow" href="/open-source">open source contributions.</a></li>
                         <li>We know we can't make the cloud better alone. Industry collaboration is important. Work together for the greater good.</li>
                     </ul>
                 </div>

--- a/source/assets/icons/inlined/small/icon-chevron-right-blue.svg
+++ b/source/assets/icons/inlined/small/icon-chevron-right-blue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYmin slice" viewBox="0 0 16 16">
+  <polygon fill="#064ccc" points="5.665 1 4 2.645 9.408 8 4 13.355 5.665 15 12.75 8"/>
+</svg>

--- a/source/assets/icons/inlined/small/icon-chevron-right-white.svg
+++ b/source/assets/icons/inlined/small/icon-chevron-right-white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <polygon fill="#ffffff" points="5.665 1 4 2.645 9.408 8 4 13.355 5.665 15 12.75 8"/>
+</svg>

--- a/source/assets/icons/inlined/small/icon-chevron-right-yellow.svg
+++ b/source/assets/icons/inlined/small/icon-chevron-right-yellow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <polygon fill="#ffeb38" points="5.665 1 4 2.645 9.408 8 4 13.355 5.665 15 12.75 8"/>
+</svg>

--- a/source/assets/js/all.js
+++ b/source/assets/js/all.js
@@ -10,6 +10,9 @@ $("document").ready(function(){
     });
     observer.observe();
     // init foundation stuff - interchange, close box, etc.
+    if (Foundation.MediaQuery.current == 'small' || Foundation.MediaQuery.current == 'medium') {
+      $('.sticky').removeAttr('data-sticky');
+    }
     $(document).foundation();
     
     // Cookie config for modal
@@ -30,3 +33,5 @@ $("document").ready(function(){
     //     console.log(newSize + ' breakpoint');
     // });
 });
+
+$(document).foundation();

--- a/source/assets/scss/modules/overrides.scss
+++ b/source/assets/scss/modules/overrides.scss
@@ -202,6 +202,32 @@
         }
     }
 }
+.link-arrow {
+    // @apply .uppercase .font-bold .text-base .no-underline .font-bold .text-green-deep .tracking-relaxed;
+    &::after {
+        transition: transform $timing-default * 2 ease, opacity $timing-default * 2 ease;
+        content: url("/assets/icons/inlined/small/icon-chevron-right-blue.svg");
+        // content: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='15' viewBox='0 0 18 15'><path d='M7.5 4.5L6.44 5.56 9.88 9l-3.44 3.44L7.5 13.5 12 9z' fill='currentColor'/><path d='M0 0h18v18H0z' fill='none'/></svg>");
+        // content: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='9' height='28'><path fill='currentColor' d='M9.297 15c0 0.125-0.063 0.266-0.156 0.359l-7.281 7.281c-0.094 0.094-0.234 0.156-0.359 0.156s-0.266-0.063-0.359-0.156l-0.781-0.781c-0.094-0.094-0.156-0.219-0.156-0.359 0-0.125 0.063-0.266 0.156-0.359l6.141-6.141-6.141-6.141c-0.094-0.094-0.156-0.234-0.156-0.359s0.063-0.266 0.156-0.359l0.781-0.781c0.094-0.094 0.234-0.156 0.359-0.156s0.266 0.063 0.359 0.156l7.281 7.281c0.094 0.094 0.156 0.234 0.156 0.359z'></path></svg>");
+        opacity: 0.6;
+        display: inline-block;
+        width:  0.8em;
+        height: 0.8em;
+        margin-left: 0.2em;
+        transform: translate3d(0px, 0.05em, 0);
+    }
+    &--white::after {
+        content: url("/assets/icons/inlined/small/icon-chevron-right-white.svg");
+    }
+    &--yellow::after {
+        content: url("/assets/icons/inlined/small/icon-chevron-right-yellow.svg");
+    }
+    &:hover:after {
+        transition: transform $timing-default * 0.5 ease, opacity $timing-default * 0.5 ease;
+        transform: translate3d(3px, 0.05em, 0);
+        opacity: 1;
+    }
+}
 .link--white-parent { // when you need to style a link inside a component/partial
     a {
         font-weight: $font-weight-bold;

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -29,7 +29,7 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
                         <% if post.has_key?("summary") %>
                             <p class="blog-date"><%= post['pub_date'].strftime('%B %-d, %Y') %></p>
                             <div class="lead"><%= Kramdown::Document.new(plain_text(post.summary)).to_html %></div>
-                            <p><a class="link--yellow read-more" href="/blog/<%= post["slug"] %>" title="Read the post">Read the post <i class="fa fa-angle-right"></i></a></p>
+                            <p><a class="link--yellow read-more" href="/blog/<%= post["slug"] %>" title="Read the post">Read the post</a></p>
                         <% end %>
                     </div>
                 </div>
@@ -48,7 +48,7 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
 </section>
 <section class="section-article">
     <div class="row">
-        <div class="columns small-12 large-9 group">
+        <div class="columns small-12 large-8 group">
             <% sorted_posts[4...10].each do | id, post | %>
                 <div class="row group row--gutter-small">
                     <div class="columns medium-3 large-3 show-for-medium">
@@ -64,13 +64,13 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
                         <% if post.has_key?("summary") %>
                             <%= Kramdown::Document.new(post["summary"]).to_html %>
                         <% end %>
-                        <p><a class="read-more" href="/blog/<%= post["slug"] %>" title="Read this post">Read on <i class="fa fa-angle-right"></i></a></p>
+                        <a class="link-arrow" href="/blog/<%= post["slug"] %>" title="Read this post">Read on</a>
                     </div>
                 </div>
             <% end %>
         </div>
-        <aside class="columns small-12 large-3 section--sidebar">
-            <%= partial "blog/partials/blog-subscription" %>
+        <aside id="subscribe" class="columns small-12 large-4 section--sidebar">
+            <%= partial "blog/partials/blog-subscription", :locals => { :color => "gray" } %>
         </aside>
     </div>
 </section>
@@ -90,13 +90,11 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
                 <% end %>
             </div>
         <% end %>
-    </div>
-    <div class="row">
-        <div class="column small-12 medium-6">
-            <%= partial "partials/snippets/button", :locals => { :label => "Browse the blog archives", :url => "/blog/archives/", :button_classes => "button", :icon => "icon-files", :icon_align => "left" } %>
-        </div>
-        <div class="column small-12 medium-6">
-            <%= partial "blog/partials/blog-subscription", :locals => {:color => "dark"} %>
+        <div class="column">
+            <div class="menu button-group align-justify">
+                <%= partial "partials/snippets/button", :locals => { :label => "Browse the blog archives", :url => "/blog/archives/", :button_classes => "button", :icon => "icon-files", :icon_align => "left" } %>
+                <%= partial "partials/snippets/button", :locals => { :label => "Get posts in your inbox", :url => "#subscribe", :button_classes => "button success", :icon => "icon-email-open-sm", :icon_align => "left" } %>
+            </div>
         </div>
     </div>
 </section>

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -54,7 +54,7 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
                     <div class="columns medium-3 large-3 show-for-medium">
                         <% if post.has_key?("featured_image") %>
                             <a href="/blog/<%= post["slug"] %>" title="Read this post">
-                                <img class="thumbnail" data-interchange="[<%= post["featured_image"]["url"] + image_thumb %>, medium]"  alt="<%= post["featured_image"]["title"] %>">
+                                <img class="thumbnail lozad" data-src="<%= post["featured_image"]["url"] %>?fit=thumb&w=300&h=300" alt="<%= post["featured_image"]["title"] %>">
                             </a>
                         <% end %>
                     </div>
@@ -64,7 +64,7 @@ sorted_posts = data.site.blog.to_a.sort_by{ |id, post| post['pub_date'] }.revers
                         <% if post.has_key?("summary") %>
                             <%= Kramdown::Document.new(post["summary"]).to_html %>
                         <% end %>
-                        <a class="link-arrow" href="/blog/<%= post["slug"] %>" title="Read this post">Read on</a>
+                        <!-- <a class="link-arrow" href="/blog/<%= post["slug"] %>" title="Read this post">Read on</a> -->
                     </div>
                 </div>
             <% end %>

--- a/source/careers.html.erb
+++ b/source/careers.html.erb
@@ -14,7 +14,7 @@ layout: "company"
         font-family: "GT-America", "Roboto", sans-serif;
     }
 </style>
-<section class="section-article container-color--dark container-image--fixed" data-interchange="[https://images.ctfassets.net/189dvqdsjh46/XrCee61laEeWoWoS6CAcI/87fd440f962b520710059ad071b869cb/background-events.jpg, small]">
+<section class="lozad section-article container-color--dark container-image--fixed" data-background-image="https://images.ctfassets.net/189dvqdsjh46/XrCee61laEeWoWoS6CAcI/87fd440f962b520710059ad071b869cb/background-events.jpg?w=1200">
     <div class="row align-center">
         <div class="columns small-12 large-8 text-center">
             <h4 class="headline-6 subheader--spaced-out text--yellow-glow">Careers</h4>
@@ -38,9 +38,9 @@ layout: "company"
 <section class="section-article container-gray-12">
     <div class="row align-middle align-center">
         <div class="columns small-12 medium-5">
-            <img class="group" src="https://images.ctfassets.net/189dvqdsjh46/1317Z506pieQaAIqmuMKK6/eec0c0a27e665c79a3a4f0be30db6b72/company-3.jpg?fit=crop&w=800&h=360" alt="Madison, WI" />
-            <img class="group" src="https://images.ctfassets.net/189dvqdsjh46/7ugfd60MRa2o4uqy4CiGyS/5b2b8be926c820195ecdd74c424e569a/company-4.jpg?w=800" alt="Datica Company Photo" />
-            <img class="group" src="https://images.ctfassets.net/189dvqdsjh46/4KnuEp6gDe2MwOIqIKuKUk/66b11ef15d7a8bcc0dd174a6a5279043/datica_team_-_hall_chat_2_P1040676.jpg" alt="Datica Company Photo" />
+            <img class="group lozad" data-src="https://images.ctfassets.net/189dvqdsjh46/1317Z506pieQaAIqmuMKK6/eec0c0a27e665c79a3a4f0be30db6b72/company-3.jpg?fit=crop&w=800&h=360" alt="Madison, WI" />
+            <img class="group lozad" data-src="https://images.ctfassets.net/189dvqdsjh46/7ugfd60MRa2o4uqy4CiGyS/5b2b8be926c820195ecdd74c424e569a/company-4.jpg?w=800" alt="Datica Company Photo" />
+            <img class="group lozad" data-src="https://images.ctfassets.net/189dvqdsjh46/4KnuEp6gDe2MwOIqIKuKUk/66b11ef15d7a8bcc0dd174a6a5279043/datica_team_-_hall_chat_2_P1040676.jpg?w=800" alt="Datica Company Photo" />
             <%            
                 # <p class="text-center">
                 #     <iframe frameborder='0' height='225px' src='https://app.tinypulse.com/happiness_badges/9f32d88ccff431ab5f9d67ce35cf7405' width='235px'>

--- a/source/compliant-kubernetes-service/index.html.slim
+++ b/source/compliant-kubernetes-service/index.html.slim
@@ -127,16 +127,28 @@ section.section-article.container-gray-11
         = partial("partials/snippets/person", :locals => { :p => the_quote.customer, :company => the_quote.customer.company_name } )
   .group.text-center
     = partial "partials/snippets/button", :locals => { :label => "Get the Case Study", :url => "/customer/methodist-lebonheur-healthcare", :button_classes => "button secondary", :icon => "icon-download", :icon_align => "right", :data_track_group => "case-study" }
-  
-  .row.align-center
-    .columns.small-12.text-center.group
-      h2.headline-3 A shared vision for the future of healthcare
-  .row.align-center.small-up-1.medium-up-2.large-up-3
-    // search by customer slug, must match CF slug strings
-    - sorted_customers = data.site.customers.to_a.select { |id, cust| (cust["slug"] == "zipnosis" || cust["slug"] == "cordata" || cust["slug"] == "metabahn" ) }
-    - sorted_customers.each do |id, cf_customer|
-      .column
-        = partial "/partials/content/card-case-study",  :locals => { :cf_customer => cf_customer } 
+
+  - case_studies = data.site.collections.to_a.select { | id, cust | (id == "3N9NeiDhwcKacuIo0E4iwu") }
+  - case_studies.each do | id, cardgroup |
+    .row.align-center
+      .columns.small-12.text-center.group
+        h2.headline-3 = cardgroup.title
+    .row.align-center.small-up-1.medium-up-2.large-up-3
+      - cardgroup["related_entries"].each do | card |
+        - carditem = data.site.caseStudy[card.id]
+        - cust = data.site.customers[carditem.customer.id]
+        .column
+          = partial "/partials/content/card-case-study",  :locals => { :cf_customer => cust } 
+
+  /.row.align-center
+  /  .columns.small-12.text-center.group
+  /    h2.headline-3 A shared vision for the future of healthcare
+  /.row.align-center.small-up-1.medium-up-2.large-up-3
+  /  // search by customer slug, must match CF slug strings
+  /  - sorted_customers = data.site.customers.to_a.select { |id, cust| (cust["slug"] == "zipnosis" || cust["slug"] == "cordata" || cust["slug"] == "metabahn" ) }
+  /  - sorted_customers.each do |id, cf_customer|
+  /    .column
+  /      = partial "/partials/content/card-case-study",  :locals => { :cf_customer => cf_customer } 
 
 section#cta.section-article.container-color--gray-dark-grad
   .row.align-center.align-middle

--- a/source/compliant-managed-integration/index.html.slim
+++ b/source/compliant-managed-integration/index.html.slim
@@ -177,7 +177,6 @@ section.section-article
   .row.align-center.group
     .columns.small-12.medium-10.large-6
       = partial("partials/cards/quote-customer", :locals => { :customer => data.site.customers['66BznN8Y482iSswswQAice'] })
-
   .row.align-center.group
     .columns.small-12.large-10.text-center
       h3.headline-3 A trusted partner with established healthcare organizations
@@ -190,6 +189,19 @@ section.section-article
       .logo-cloud
         - data.views.ehrs.ehr_list.each do |logo|
           img alt="#{logo["name"]}" class=("lozad logo-cloud--item logo-size--#{logo['logoSize']}") data-src="/public/img/customer-logos/sm/#{logo["slug"]}-logo.png" /
+section.section-article.container-gray-12
+  - case_studies = data.site.collections.to_a.select { | id, cust | (id == "6wxpCFBxTy6aKEYQoEU4Y4") }
+  - case_studies.each do | id, cardgroup |
+    .row.align-center
+      .columns.small-12.text-center.group
+        h2.headline-3 = cardgroup.title
+    .row.full-width.align-center.small-up-1.medium-up-2.large-up-3.xlarge-up-4
+      - cardgroup["related_entries"].each do | card |
+        - carditem = data.site.caseStudy[card.id]
+        - cust = data.site.customers[carditem.customer.id]
+        .column
+          = partial "/partials/content/card-case-study",  :locals => { :cf_customer => cust } 
+
 
 section#cta.section-article.container-color--gray-dark-grad
   .row.align-center.align-middle

--- a/source/contentful_templates/blog.html.erb
+++ b/source/contentful_templates/blog.html.erb
@@ -135,7 +135,7 @@ end
 <% if p.has_key?("related_entries") && p["related_entries"].count > 1 %>
     <section class="section-article--med container-gray-10">
         <h4 class="headline-5 text--spaced text-center group">Related</h4>
-        <div class="row full-width small-up-1 medium-up-2 large-up-3 xxlarge-up-4 align-center">
+        <div class="row full-width small-up-1 medium-up-2 large-up-3 xlarge-up-4 align-center">
             <% p["related_entries"].each do | relatedPost | %>
             <% 
             # mapping content type to paths. How could this be a ruby helper or function?
@@ -146,7 +146,7 @@ end
             #end
             #related_post_path = "/" + url_segment + "/" + relatedPost.slug 
             %>
-                <div class="column">
+                <div class="column group">
                     <%= partial "partials/cards/featured-blog", :locals => { :post => relatedPost, :style => "light", :size => "small" } %>
                 </div>
             <% end %>

--- a/source/contentful_templates/customer.html.erb
+++ b/source/contentful_templates/customer.html.erb
@@ -84,11 +84,6 @@ end
                     <h3 class="headline-4 text-center group">Read the Case Study</h3>
                     <%= partial "partials/snippets/form", :locals => { :the_form => p["case_study"]["related_form"]["custom_form"] } %>
                 </div>
-            <% elsif p["case_study"].has_key?("form_id") %>
-                <div class="callout callout--large drop">
-                    <h3 class="headline-4 text-center group">Download this case study for free</h3>
-                    <%= partial("partials/snippets/form-hubspot", :locals => { :form_id => p["case_study"]["form_id"] }) %>
-                </div>
             <% end %>
             </div>
         </div><!-- END row -->

--- a/source/contentful_templates/event.html.erb
+++ b/source/contentful_templates/event.html.erb
@@ -33,37 +33,7 @@ end
 <section class="section-article container-color--gray-light">
     <div class="row align-center">
         <div class="columns small-12 large-8">
-                <% if p.has_key?("event_logo") %>
-                    <p><img class="logo-size--medium" src="<%= p["event_logo"]["url"] %>?w=300" alt="Event Logo"></p>
-                <% end %>
-                <h1 class="headline-3"><%= p["title"] %></h1>
-                <h4 class="headline-5 spaced-out">
-                    <%= inline_svg("small/icon-event-note", class: "icon-inline svg-color--gray-5") %>
-                    <%= partial("partials/snippets/date-range", :locals => { :p => p }) %>
-                </h4>
-                <div class="content-dynamic group">
-                    <% if p.has_key?("event_related_people") %>
-                        <div class="float-right-on-medium">
-                            <% p["event_related_people"].each do |person| %>
-                                <%= partial("partials/snippets/person", :locals => { :p => person, :classes => "block-width-medium", :use_headers => false }) %>
-                            <% end %>
-                        </div>
-                    <% end %>
-                    <%= Kramdown::Document.new(p["event_desc"]).to_html %>
-                    <% if p.has_key?("event_photos") %>
-                        <% p["event_photos"].each do |photo| %>
-                            <img class="thumbnail" src="<%= photo.url %>?w=500" title="<%= photo.title %>" width="300"> 
-                        <% end %>
-                    <% end %>
-                    <% if p.has_key?("event_tags") %>
-                        <p class="group">
-                            <% p["event_tags"].each do |tag| %>
-                                <span class="label faded round secondary"><%= tag %></span>
-                            <% end %>
-                        </p>
-                    <% end %>
-                    <%#= partial "/partials/snippets/share", :locals => { :p => p, :classes => "" }  %>
-                </div>
+            <%= partial "partials/content/event", :locals => { :event => p } %>
             <% if p.has_key?("cta_ref") %>
                 <% if p["cta_ref"].has_key?("custom_form") %>
                 <div class="row collapse">

--- a/source/events/index.html.erb
+++ b/source/events/index.html.erb
@@ -33,42 +33,7 @@ sorted_events = data.site.events.to_a.sort_by{ |id, event| event['date_start'] }
             <% sorted_events.each do |id, event| %>
                 <% if today.strftime("%F") < event['date_start'].strftime("%F") %>
                     <div class="callout callout--large drop group--2x">
-                        <% if event.has_key?("title") %>
-                            <h4 class="headline-4 group">
-                                <a href="/events/<%= event["slug"]%>" title="event details">
-                                    <%= event["title"]%>
-                                </a>
-                            </h4>
-                        <% end %>
-                        <% if event.has_key?("event_related_people") %>
-                            <div class="float-right-on-medium">
-                                <% event["event_related_people"].each do |person| %>
-                                    <%= partial("partials/snippets/person", :locals => { :p => person, :classes => "block-width-medium", :use_headers => false }) %>
-                                <% end %>
-                            </div>
-                        <% end %>
-                        <% if event.has_key?("event_logo") %>
-                            <p><img class="logo-size--medium lozad" data-src="<%= event["event_logo"]["url"] %>?w=300" alt="Event logo"></p>
-                        <% end %>
-                        <div class="headline-5 spaced-out">
-                        <%= inline_svg("small/icon-event-note", class: "icon-inline svg-color--gray-5") %>
-                        <%= partial("partials/snippets/date-range", :locals => { :p => event }) %>
-                        </div>
-                        <% if event.has_key?("event_desc") %>
-                            <%= Kramdown::Document.new(event["event_desc"]).to_html %>
-                        <% end %>
-                        <% if event.has_key?("event_photos") %>
-                            <% event["event_photos"].each do |photo| %>
-                                <img class="thumbnail" src="<%= photo.url %>?w=500" title="<%= photo.title %>" width="300"> 
-                            <% end %>
-                        <% end %>
-                        <% if event.has_key?("event_tags") %>
-                            <p class="">
-                                <% event["event_tags"].each do |tag| %>
-                                    <span class="label faded round<% if tag == "Sponsor" %> success<% else %> info<% end %>"><%= tag %></span>
-                                <% end %>
-                            </p>
-                        <% end %>
+                        <%= partial "partials/content/event", :locals => { :event => event } %>
                     </div>
                 <% end %>
             <% end %>

--- a/source/events/index.html.erb
+++ b/source/events/index.html.erb
@@ -14,15 +14,20 @@ current_page.data.date = today.strftime('%B %-d, %Y')
 sorted_events = data.site.events.to_a.sort_by{ |id, event| event['date_start'] }.reverse!
 %>
 
-<section class="section-article container-color--dark container-image--fixed lozad" data-background-image="https://images.ctfassets.net/189dvqdsjh46/XrCee61laEeWoWoS6CAcI/87fd440f962b520710059ad071b869cb/background-events.jpg">
+<section class="section-article container-color--gray-light">
     <div class="row align-center">
-        <div class="columns small-12 large-8 text-center">
-            <h1 class="headline-6 subheader--spaced-out text--yellow-glow">Events</h1>
-            <h2 class="headline-2">Speaking engagements, conferences, and events</h2>
+        <div class="columns small-12 large-7 text-center">
+            <h1 class="headline-4 spaced-out">Datica Events</h1>
+            <h2 class="headline-4 text-light group">Nationally recognized speakers on compliance and healthcare</h2>
+        </div>
+        <div class="columns small-12 large-10 group">
+            <div class="logo-cloud text-center">
+                <% data.views.events.speaking_list.each do |logo| %>
+                    <img data-src="<%= logo["logo_file"] %>?w=300" alt="<%= logo["name"] %>" class="lozad logo-cloud--item logo-size--<%= logo['logoSize'] %>" />
+                <% end %>
+            </div>
         </div>
     </div>
-</section>
-<section class="section-article container-color--gray-light">
     <div class="row align-center">
         <div class="columns small-12 medium-10 large-8">
             <% sorted_events.take(1).each do |id, event| %>
@@ -30,23 +35,13 @@ sorted_events = data.site.events.to_a.sort_by{ |id, event| event['date_start'] }
                     <h3 class="headline-3 text-center group">Upcoming Events</h3>
                 <% end %>
             <% end %>
-            <% sorted_events.each do |id, event| %>
+            <% sorted_events.reverse.each do |id, event| %>
                 <% if today.strftime("%F") < event['date_start'].strftime("%F") %>
                     <div class="callout callout--large drop group--2x">
                         <%= partial "partials/content/event", :locals => { :event => event } %>
                     </div>
                 <% end %>
             <% end %>
-        </div>
-        <div class="columns small-12 large-7 text-center">
-            <h2 class="headline-3 group">Nationally recognized speakers on compliance and healthcare</h2>
-        </div>
-        <div class="columns small-12 large-10">
-            <div class="logo-cloud text-center">
-                <% data.views.events.speaking_list.each do |logo| %>
-                    <img data-src="<%= logo["logo_file"] %>?w=300" alt="<%= logo["name"] %>" class="lozad logo-cloud--item logo-size--<%= logo['logoSize'] %>" />
-                <% end %>
-            </div>
         </div>
     </div>
 </section>

--- a/source/events/index.html.erb
+++ b/source/events/index.html.erb
@@ -125,9 +125,9 @@ sorted_events = data.site.events.to_a.sort_by{ |id, event| event['date_start'] }
                                         <% end %>
                                     <% end %>
                                 </ul>
-                                <% if event.has_key?("event_desc") %>
+                                <% if event.has_key?("summary") %>
                                     <div class="content-dynamic">
-                                        <%= Kramdown::Document.new(event["event_desc"]).to_html %>
+                                        <%= Kramdown::Document.new(event["summary"]).to_html %>
                                     </div>
                                 <% end %>
                                 <% if event.has_key?("event_image") %>

--- a/source/partials/content/_card-case-study.erb
+++ b/source/partials/content/_card-case-study.erb
@@ -11,14 +11,15 @@
         <a href="/customer/<%= cf_customer["slug"] %>" title="<%= cf_customer["company_name"] %> case study">
             <img class="logo-size--medium group--sm" src="/public/img/customer-logos/<%= cf_customer["slug"] %>-logo.png" alt="<%= cf_customer["company_name"] %> Logo"/>
         </a>
-        <h3 class="headline-5"><%= cf_customer["case_study"]["case_study_title"] %></h3>
+        <h3 class="lead"><%= cf_customer["case_study"]["case_study_title"] %></h3>
     </div>
     <div class="card-section card-section--flush text-left">
         <% if cf_customer["case_study"].has_key?("customer_quote") %>
                 <blockquote class="quote--serif">
-                    <%= cf_customer["case_study"]["customer_quote"]["quote_body"] %>
+                    <%= Kramdown::Document.new(cf_customer["case_study"]["customer_quote"]["quote_body"]).to_html %>
+
                 </blockquote>
-                <%= partial("partials/snippets/person", :locals => { :p => cf_customer }) %>
+                <%= partial("partials/snippets/person-vertical-simple", :locals => { :p => cf_customer }) %>
         <% else %>
             <% if cf_customer["case_study"].has_key?("value_prop") %>
                 <p class="lead"><%= cf_customer["case_study"]["value_prop"] %></p>

--- a/source/partials/content/_event.slim
+++ b/source/partials/content/_event.slim
@@ -1,0 +1,29 @@
+.row
+  .columns
+    - if event.has_key?("title")
+      h3.headline-4
+        a href="/events/#{event["slug"]}" title=("event details") 
+          = event["title"]
+    h4.headline-6.spaced-out
+      = inline_svg("small/icon-event-note", class: "icon-inline svg-color--gray-5")
+      | &nbsp;
+      = partial("partials/snippets/date-range", :locals => { :p => event })
+  - if event.has_key?("event_logo")
+    .columns.small-5.medium-large-4
+      img.logo-size--medium.lozad alt=("Event logo") data-src="#{event["event_logo"]["url"]}?fm=png&w=300" /
+.row
+  .column
+    - if event.has_key?("event_desc")
+      = Kramdown::Document.new(event["event_desc"]).to_html
+    - if event.has_key?("event_photos")
+      - event["event_photos"].each do |photo|
+        img.thumbnail src="#{photo.url}?w=500" title="#{photo.title}" width="300" /
+    - if event.has_key?("event_tags")
+      p
+        - event["event_tags"].each do |tag|
+          - if tag == 'Sponsor' ? tagstyle = 'success' : tagstyle = 'info'
+          span class=("label faded round #{tagstyle}") = tag
+  - if event.has_key?("event_related_people")
+    .columns.small-5.medium-large-4
+      - event["event_related_people"].each do |person|
+        = partial("partials/snippets/person-small", :locals => { :p => person, :classes => "block-width-medium", :use_headers => false })

--- a/source/partials/snippets/_form.slim
+++ b/source/partials/snippets/_form.slim
@@ -2,5 +2,10 @@ ruby:
 	unless defined?(the_form)
 		puts "The form partial at #{current_page.url} is not defined!"
 	end
-#hsFormContainer
+	if defined?(formId) # ex :formId => 'foo'; in case there's more than 1 embed on a page
+		formAnchor = '#' + formId
+	else
+		formAnchor = '#hsFormContainer'
+	end
+div id = formAnchor
 = Kramdown::Document.new(the_form).to_html

--- a/source/seldon/dhsf-plain.html.erb
+++ b/source/seldon/dhsf-plain.html.erb
@@ -1,0 +1,191 @@
+---
+title: "Digital Health Success Framework"
+navTitle: DHSF
+summary: "DHSF in full-page form."
+customCSS: dhsf
+hide_from_sitemap: true
+---
+<style type="text/css">
+    /*li.menu-item {
+        ;
+    }*/
+    .df .menu li > a {
+        padding-left: 1rem;
+    }
+    .menu-item--link {
+        border-bottom: 3px solid transparent;
+    }
+    .is-current {
+        color: black;
+        border-bottom: 3px solid blue;
+    }
+    .is-current:hover {
+        transition: all 200ms linear;
+        /*background-color: white(0);*/
+        border-bottom: 3px solid blue;
+    }
+    .df-stage--timeline {
+        z-index: initial;
+    }
+    .df-stage--timeline__line {
+        top: -2px;
+        margin-bottom: 2rem;
+    }
+    .df-stage--dot-group {
+        top: initial;
+        margin-bottom: initial;
+        z-index: 3;
+    }
+</style>
+<div class="df dhsf">
+    <section class="section-article container-gray-12" id="df-top">
+        <div class="row">
+            <div class="columns small-12 medium-10 large-8">
+                <h1 class="subhead--small text--spaced">The Digital Health Success Framework</h1>
+                <p class="lead">The Digital Health Success Framework (DHSF) is a simple guide for the makers of digital healthcare products.</p>
+                <p class="lead">The Internet is full of  resources to help turn ideas into lean startups or businesses, but things are a little different in the wild wild west of digital health technology. There are considerations in healthcare not found in any other industry, and no one has time to learn them all.</p>
+                <p class="lead">We’ve simplified the unique complexities to help you get your digital health products from napkin scribble to market adoption with fewer surprises. You will leave with a better understanding of how to manage the challenges ahead.</p>
+                <p>It purposefully has a narrow scope, giving guidance around five main topics:</p>
+                <ul>
+                    <% data.views.dhsf.phases.each_with_index do |phase, id| %>
+                        <li><strong><%= phase["label"] %></strong>: <%= phase["desc"] %></li>
+                    <% end %>
+                </ul>
+            </div>
+        </div>
+    </section>
+    <div id="topicNav" class="show-for-medium group" data-sticky-container>
+        <nav class="sticky sticky-nav container-color--white drop-light text-center full-width" data-sticky data-options="marginTop:0; topAnchor:topicNav;">
+            <ul class="menu horizontal align-center align-middle" data-magellan data-options="activeClass:is-current; offset: 50; animationEasing: swing">
+                <li class="subhead--small text--spaced menu-item ">Topics</li>
+                <% data.views.dhsf.phases.each_with_index do |phase, id| %>
+                    <li class="menu-item">
+                        <a href="#df-<%= phase["slug"] %>-strategy" title="<%= phase["label"] %>" class="menu-item--link">
+                            <%= phase["label"] %>
+                        </a>
+                    </li>
+                <% end %>
+            </ul>
+        </nav>
+    </div>
+    <div id="content" class="df-container">
+        <% data.views.dhsf.phases.each_with_index do |phase, id| %>
+            <section id="df-<%= phase["slug"] %>-strategy" class="df-phase--section" data-magellan-target="df-<%= phase["slug"] %>-strategy">
+
+                <div class="row df-stage--timeline">
+                    <div class="columns small-12 large-12 df-stage--dot-group">
+                        <h1 class="headline-3 no-wrap df-phase--title">
+                            <%= phase["label"] %>
+                        </h1>
+                        <p class="lead"><%= phase["desc"] %></p>
+                    </div>
+                </div>
+                <!-- <div class="df-stage--timeline__line"></div> -->
+                <div id="df-<%= phase["slug"] %>-stage-content" class="_tabs-content df-stage" data-animate="fade-in fade-out" _data-tabs-content="df-stage--timeline-<%= id %>">
+                    <% phase["stages"].each_with_index do |stage, index| %>
+                        <div id="<%= phase["slug"] %>-<%= stage["slug"] %>" class="_tabs-panel df-stage--item">
+                            <div class="row">
+                                <div class="columns small-12 large-8">
+                                    <h3 class="subheader-small text--blue">Month <%= stage["time"] %></h3>
+                                    <h2 class="headline-5">
+                                        <%= stage["title"] %> <a class="faded" href="/dhsf/#<%= phase["slug"] %>-<%= stage["slug"] %>" title="A link to the DHSF entry for '<%= stage["title"] %>'.">#</a>
+                                    </h2>
+                                    <% if phase.has_key?("lead") %>
+                                        <div class="lead df-phase--lead" data-columns="false">
+                                            <%= Kramdown::Document.new(phase["lead"]).to_html %>
+                                        </div>
+                                    <% end %>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="columns small-12 large-8">
+                                    <div class="df-stage--content">
+                                        <div class="content-dynamic group"><%= Kramdown::Document.new(stage["body"]).to_html %></div>
+                                    </div>
+                                </div>
+                                <div class="columns small-12 large-4">
+                                    <% if stage.has_key?("asides") %>
+                                        <% stage["asides"].each do |aside| %>
+                                            <div class="group"><%= aside %></div>
+                                        <% end %>
+                                    <% end %>
+                                    <% if stage.has_key?("discovery_topic") %>
+                                        <% related_discover = data.site.discover[stage.discovery_topic.to_s] %>
+                                        <%= partial "/partials/cards/discover", :locals => { :post => related_discover, :classes => "group" } %>
+                                    <% end %>
+                                    <% if stage.has_key?("customer_id") %>
+                                        <% related_customer = data.site.customers[stage.customer_id.to_s] %>
+                                            <%= partial "/partials/content/card-case-study-compact",  :locals => { :cf_customer => related_customer, :subhead => "case study" } %>
+                                    <% end %>
+                                    <% if stage.has_key?("quote_id") %>
+                                        <% related_quote = data.site.quotes[stage.quote_id.to_s] %>
+                                    <% end %>
+                                </div>
+                            </div>
+                        </div>
+                    <% end %>
+                </div>
+            </section>
+        <% end %>
+    </div>
+    <section class="section-article container-gray-12">
+        <div class="row align-center">
+            <div class="columns small-12 medium-10 large-8">
+                <div class="group text-center">
+                    <h4 class="subhead--small text--spaced">Background</h4>
+                    <h2 class="headline-3">The Details Behind the Framework</h2>
+                </div>
+            </div>
+        </div>
+        <div class="row align-center">
+            <div class="columns small-12 medium-6 large-4">
+                <h3 class="headline-4" id="living-document">This is a living document</h3>
+                <p>The guide will be constantly evolving. Developing new articles and strategies are an on-going effort as Datica continues to have rich conversations with the market.</p>
+                <p>If you have any feedback, send an email to <strong>hello@datica.com</strong>. We love community input, but more importantly, we love to hear your story.</p>
+                <h3 class="headline-4" id="what-this-framework-is-not">What this framework is not</h3>
+                <p>Don’t mistake the DHSF as an all-encompassing guide to successful company-building. A successful business succeeds along innumerable dimensions, outside of compliance, infrastructure, or integration. This framework is not those ingredients:</p>
+                <ul>
+                    <li>Fundraising advice</li>
+                    <li>Company formulation practices</li>
+                    <li>Lean startup principles</li>
+                    <li>How to hire</li>
+                    <li>How to develop a strategy</li>
+                    <li>And so on</li>
+                </ul>
+                <p>That’s what incubators like YCombinator or Gener8tor do, or programs like Cedars-Sinai+TechStars, focus on.</p>
+                <p>Specific to healthcare, this framework does not go deep into FDA regulations or life science particulars like GxP. While there is significant overlap with our expertise in compliance, we aren’t yet experts in those arenas to provide a detailed guide on
+                    navigating the FDA or meeting GxP requirements. We will furnish helpful external resources to learn more elsewhere, however.</p>
+            </div>
+            <div class="columns small-12 medium-6 large-4">
+                <h3 class="headline-4" id="how-we-became-experts">How We Became Experts</h3>
+                <p>Over the last 4-plus years, Datica has engaged with thousands of digital health organizations, from single-founder startups to groups within Fortune 100 companies like Johnson &amp; Johnson or UnitedHealthcare. We often chat with them as they are figuring
+                    out how to deal with HIPAA compliance or data exchange. Some were far enough along with their idea to become customers, but many did not as they first searched for traction.</p>
+                <p>Over the course of several thousand conversations, we started to see clear patterns emerge around topics like technology, infrastructure, compliance, and interoperability. This framework is the distillation of what matters to the success of digital health
+                    products.
+                </p>
+                <p>Datica is not going to pretend we know the entire scope of what it takes to make a successful business—things like capitalization strategies or Lean Startup advice—or the best methodologies for product development—like debating waterfall vs. agile, or
+                    outcome-driven innovation. But we <em>do</em> have one of the most credible points of view on the technological underpinnings of digital health. Companies and teams, ideas and innovations, can look to this framework to obtain a stronger handle on
+                    an intelligent way to manage the underlying burdens unique to digital health products.</p>
+            </div>
+            <div class="columns small-12 medium-6 large-4">
+                <div class="callout callout--dark group">
+                    <div class="text-center">
+                        <h3 class="headline-4 nomargin" id="company-snapshot">Company Snapshot</h3>
+                        <div class="pub-date">As of July 1, 2017</div>
+                    </div>
+                    <ul>
+                        <li>3,272 unique organizations, companies, groups, and individuals with which we have engaged via a business relationship. Each one we heard their story, understood their needs, and observed their trajectory.</li>
+                        <li>Hundreds of digital health customers</li>
+                        <li>More than 200 integration partners</li>
+                    </ul>
+                </div>
+                <div class="group text-center">
+                    <a href="https://datica.com/guide/digital-health-success-framework-ebook/" title="Download your ebook">
+                        <img src="https://images.ctfassets.net/189dvqdsjh46/2q4JydYcuAgSQ6SKmy88US/47ce92d94666f955ab2ef252297fa838/dhsf-report-preview.png?w=500" alt="DHSF Ebook" class="group">
+                    </a>
+                    <a class="button hollow" href="/guide/digital-health-success-framework-ebook/" title="Download your ebook">Get your free DHSF ebook today</a>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## New: Collections

There's been a long-time need for generic collections of entries like features, posts, case studies, etc. I've added and implemented basic support for this on the app side. These are for custom collections of things that we want some editorial control over in Contentful.

Contentful now has a new group of entries in the sidebar: 
<img src="https://user-images.githubusercontent.com/887931/44822695-37e33b80-abb1-11e8-889e-4e6ac22acb8b.png" width="33%" />

The first use of these is to display curated case studies in product pages. Editors can now select and reorder these in Contentful. 

Note that the _display_ of each entry is completely bespoke; each "collection" entry must be grabbed in the template. Here's an example on a product page: 

```slim
  - case_studies = data.site.collections.to_a.select { | id, cust | (id == "6wxpCFBxTy6aKEYQoEU4Y4") }
  - case_studies.each do | id, cardgroup |
    .row.align-center
      .columns.small-12.text-center.group
        h2.headline-3 = cardgroup.title
    .row.full-width.align-center.small-up-1.medium-up-2.large-up-3.xlarge-up-4
      - cardgroup["related_entries"].each do | card |
        - carditem = data.site.caseStudy[card.id]
        - cust = data.site.customers[carditem.customer.id]
        .column
          = partial "/partials/content/card-case-study",  :locals => { :cf_customer => cust } 
```

Renders this:

![image](https://user-images.githubusercontent.com/887931/44822769-bfc94580-abb1-11e8-8fe2-46b49b5bbb79.png)

## Other fixes
Various other improvements and polish, particularly in Events (improved future events, layout) and Blogs (bugfixes in mobile forms, cleanup of layout a bit). 