### PR TITLE
Feature/webinar events

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,7 @@ helpers SiteHelpers
 helpers ImageHelpers
 # helpers AriaCurrent
 
-Time.zone = 'UTC'
+Time.zone = 'America/Chicago'
 
 # Files with no layout
 page '/*.xml', layout: false

--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,7 @@ helpers SiteHelpers
 helpers ImageHelpers
 # helpers AriaCurrent
 
-Time.zone = 'America/Chicago'
+Time.zone = 'Central Time (US & Canada)'
 
 # Files with no layout
 page '/*.xml', layout: false

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -20,7 +20,7 @@ ruby:
         current_page.data.author = "Datica, Inc."
     end
     if p.has_key?("event_date")
-        event_date = p['event_date'].strftime('%A, %B %-d, %Y, %l %p') + ' CDT'
+        event_date = p['event_date'].in_time_zone(-5).strftime('%A, %B %-d, %Y, %l %p') + ' CDT'
         current_page.data.date = event_date
         if today.strftime("%F") >= p['event_date'].strftime("%F")
             is_future = false # puts "this already happened"
@@ -108,6 +108,7 @@ ruby:
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
             .columns.small-12.large-6
                 h4.headline-5
+                    p = today.in_time_zone(-7).strftime('%A, %B %-d, %Y, %l:%M %p')
                     = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
                     span = event_date
                 - if p.has_key?("lead")

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -5,7 +5,7 @@ asset_preload: '<link href="https://js.hsforms.net/forms/v2.js" rel="preload" as
 customJS: "/public/js/webinar.js"
 ---
 ruby:
-    today = DateTime.now
+    today = DateTime.now.utc
     p = locals[:item]
     current_page.data.title = p["title"] + " | Datica Webinars"
     current_page.data.summary = safe_summary(p.summary)
@@ -20,7 +20,8 @@ ruby:
         current_page.data.author = "Datica, Inc."
     end
     if p.has_key?("event_date")
-        event_date = p['event_date'].strftime('%A, %B %-d, %Y, %l %P') + ' CST'
+        event_date = p['event_date'].strftime('%A, %B %-d, %Y, %l %p') + ' CDT'
+        current_page.data.date = event_date
         if today.strftime("%F") >= p['event_date'].strftime("%F")
             is_future = false # puts "this already happened"
         else
@@ -91,7 +92,7 @@ ruby:
                     .is-registered.callout.drop.hide
                         = inline_svg("small/icon-check-circle", class: "float-right icon-size--large svg-color--green")
                         h3.headline-4 You're Registered!
-                        p Join us <strong>#{p['event_date'].strftime('%A, %B %-d, %Y, %l %P')} CST</strong>
+                        p Join us <strong>#{p['event_date'].strftime('%A, %B %-d, %Y, %l %P')} CDT</strong>
                 /#webinar-title.hide
                     h2.headline-4 = p["title"]
                     - if p.has_key?("authors")

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -20,7 +20,10 @@ ruby:
         current_page.data.author = "Datica, Inc."
     end
     if p.has_key?("event_date")
-        event_date = p['event_date'].in_time_zone(-5).strftime('%A, %B %-d, %Y, %l %p') + ' CDT'
+        event_date = p["event_date"].to_s.in_time_zone("Central Time (US & Canada)").strftime('%A, %B %-d, %Y, %l:%M %p %Z')
+        # puts the_day
+        # puts config.Time.zone
+        #event_date = p['event_date'].strftime('%A, %B %-d, %Y, %l:%M %p') + ' CDT'
         current_page.data.date = event_date
         if today.strftime("%F") >= p['event_date'].strftime("%F")
             is_future = false # puts "this already happened"
@@ -108,7 +111,7 @@ ruby:
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
             .columns.small-12.large-6
                 h4.headline-5
-                    p = today.in_time_zone(-7).strftime('%A, %B %-d, %Y, %l:%M %p')
+                    /p = today.in_time_zone("Central Time (US & Canada)").strftime('%A, %B %-d, %Y, %l:%M %p')
                     = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
                     span = event_date
                 - if p.has_key?("lead")

--- a/source/partials/cards/_webinar-poster.slim
+++ b/source/partials/cards/_webinar-poster.slim
@@ -12,7 +12,7 @@ ruby:
     end
     today = DateTime.now
     if entry.has_key?("event_date")
-        event_date = entry['event_date'].strftime('%A, %B %-d, %Y, %l %P') + ' CST'
+        event_date = entry["event_date"].to_s.in_time_zone("Central Time (US & Canada)").strftime('%B %-d, %Y, %l:%M %p %Z')
         if today.strftime("%F") >= entry['event_date'].strftime("%F")
             is_future = false # puts "this already happened"
         else
@@ -30,14 +30,14 @@ a.preview.container-gray-2.relative href="/webinars/#{entry["slug"]}" title=("Vi
     .webinar-meta.z-stack-10.relative
         .preview-subhead Datica Webinar
         .preview-title
-            h2.headline-3 = entry["title"]
-        .menu.simple
-            li
-                = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
-                span = entry['event_date'].strftime('%B %-d, %Y')
-            - if entry.has_key?("discovery_topic")
-                li
-                    span.label.info.round = data.site.discover[entry.discovery_topic.id].title
+            h2.headline-3.nomargin = entry["title"]
+        div.preview-info(style="margin-bottom: 0.2em;")
+            = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
+            / span = entry['event_date'].strftime('%B %-d, %Y')
+            span = event_date
+        - if entry.has_key?("discovery_topic")
+            div.preview-topic
+                span.label.dark.round = data.site.discover[entry.discovery_topic.id].title
     .absolute.preview-bg.z-stack-0.group
         img.lozad.img-cover.img-multiply.blur-1 src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=800"
     .preview-cta.headline-5.spaced-out.show-for-large.text-right = cta_label


### PR DESCRIPTION
Improved date/time handling, specifically showing the proper hour and DST value from contentful.

- Webinar list view
- Webinar card preview partial (shows in lots of places)
- Set middleman app time zone so it thinks it's in Madison 🧀 

![image](https://user-images.githubusercontent.com/887931/45848700-533ef380-bce4-11e8-9e09-a8ddd10c7d9e.png)
