### PR TITLE
Webinar visual fixes

### DIFF
--- a/source/assets/js/webinar.js
+++ b/source/assets/js/webinar.js
@@ -1,8 +1,12 @@
 $("document").ready(function(){
     var webinarId = $('#webinar').data('webinar');
     function showWebinar(){
+        // $('nav.nav-desktop').attr('data-theme', 'dark');
+        $('#webinar').attr('data-theme', 'dark');
+        $('#webinar').addClass("container-gray-3");
         $('#webinar-play').removeClass("hide");
-        // $('.preview-bg').addClass("diffuse");
+        $('#webinar-authors').addClass("hide");
+        $('.preview-bg').addClass("hide");
         // $('#webinar-play').addClass("group");
         $('#preview-register').addClass("hide");
         // $('#preview-registered').removeClass("hide");
@@ -12,7 +16,12 @@ $("document").ready(function(){
         console.log('show it');
     }
     function hideWebinar(){
+        // $('nav.nav-desktop').attr('data-theme', 'dark');
+        $('#webinar').attr('data-theme', 'light');
+        $('#webinar').removeClass("container-gray-3");
         $('#webinar-play').addClass("hide");
+        $('#webinar-authors').removeClass("hide");
+        $('.preview-bg').removeClass("hide");
         // $('#preview-register').removeClass("hide");
         // $('#preview-registered').addClass("hide");
         // $('#webinar-title').addClass("hide");

--- a/source/assets/scss/modules/buttons.scss
+++ b/source/assets/scss/modules/buttons.scss
@@ -36,9 +36,11 @@
     &--light, &--tertiary { // use these on dark or busy backgrounds
         @include gradient(to bottom, white 0%, $gray-12 100%);
         // @include shadow-anarchy(inset 0 -1px 2px 0 #B3C8D6);
-        color: darken($color_product, 20%);
+        // background-color: $gray-12;
+        color: darken($color_product, 20%) !important; // not sure what .container rule is overriding this, it's lower in the OOO
         &:hover, &:active, &:focus {
-            color: black;
+            color: black !important;
+            background-color: white;
             // @include gradient(to bottom, $gray-12 0%, $gray-11 100%);
         }
     }

--- a/source/assets/scss/modules/containers.scss
+++ b/source/assets/scss/modules/containers.scss
@@ -217,6 +217,10 @@
             }
             @else {
                 color: #fff;
+                a { // better defaults for dark containers
+                    color: white;
+                    &:hover, &:active, &:focus {color: $color_yellow-glow; }
+                }
             }
             background-color: $color;
             // &:after {
@@ -386,11 +390,14 @@
             @else {
                 color: #fff;
             }
-            background: $color;
+            background-color: $color;
             // padding: 0.3em;
             // display: inline-block;
         }
     }
+}
+[class*="container"], [class*="bg"] {
+    transition: background-color $timing-default linear, color $timing-default linear;
 }
 // Vertical align helper
 .vertical-align {

--- a/source/assets/scss/modules/hero.scss
+++ b/source/assets/scss/modules/hero.scss
@@ -1,4 +1,4 @@
 // global heroes!
-.hero{
-    //..
-}
+// .hero{
+//     //..
+// }

--- a/source/assets/scss/modules/links.scss
+++ b/source/assets/scss/modules/links.scss
@@ -11,3 +11,5 @@ a {
 section a {
     font-weight: $font-weight-mid;
 }
+// note that containers.scss:211 currently loads after this file; 
+// there are basic link style overrides per container colors (at least for grays)

--- a/source/assets/scss/seldon.scss
+++ b/source/assets/scss/seldon.scss
@@ -75,13 +75,13 @@
 @import 'modules/components';
 @import 'modules/callouts';
 @import 'modules/cards';
-@import 'modules/buttons';
 // @import 'modules/hero';
 @import 'modules/tables';
 @import 'modules/modal';
 @import 'modules/content';
 @import 'modules/masonry';
 @import 'modules/people';
+@import 'modules/buttons';
 @import 'modules/webinars';
 @import 'sitewide';
 

--- a/source/contentful_templates/report.html.slim
+++ b/source/contentful_templates/report.html.slim
@@ -75,6 +75,6 @@ section.section-article--med.container-gray-11
                     = partial "partials/snippets/form", :locals => { :the_form => p["related_form"]["custom_form"] }
 
 - if p.has_key?("bg_image")
-    section.show-for-medium.section-article.container-image-fill data-background-image="#{p.bg_image.url}?fit=thumb&w=1800&h=400&fm=jpg&q=50"
+    section.lozad.show-for-medium.section-article.container-image-fill data-background-image="#{p.bg_image.url}?fit=thumb&w=1800&h=400&fm=jpg&q=50"
 - else
-    section.show-for-medium.container-gray-5.container-image--fixed data-background-image="//images.ctfassets.net/189dvqdsjh46/3gflDVmPuoecamYsY6OOSI/90c46d15b8af71129e3612ac010c0574/city_blurry_bokeh_chuttersnap-179223.jpg?fit=thumb&w=1800&h=200&fm=jpg&q=50"
+    section.lozad.show-for-medium.container-gray-5.container-image--fixed data-background-image="//images.ctfassets.net/189dvqdsjh46/3gflDVmPuoecamYsY6OOSI/90c46d15b8af71129e3612ac010c0574/city_blurry_bokeh_chuttersnap-179223.jpg?fit=thumb&w=1800&h=200&fm=jpg&q=50"

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -52,15 +52,15 @@ ruby:
 .strip-bright.strip-bright--small
 .container-gray-11
     = partial "partials/head/header", :locals => { :style => "dark" }
-    section#webinar.section-article data-webinar = p._meta.id
+    section#webinar.section-article--med data-webinar = p._meta.id
         .row.align-center
             .columns.small-12.large-6.text-center.group
-                = inline_svg("icon-webinar", class: "icon-size--large")
-                h2.headline-5.spaced-out
-                    a.link--dark href="/webinars" Datica Webinars
+                a href="/webinars" title="See all webinars"
+                    = inline_svg("icon-webinar", class: "icon-size--large")
+                    h2.headline-5.spaced-out Datica Webinars
         .row.align-center
             .columns.small-12.large-10.group
-                #webinar-container.preview.container-gray-2.relative href="/webinars/#{p["slug"]}" title=("View webinar")
+                #webinar-container.preview.container-gray-3.relative href="/webinars/#{p["slug"]}" title=("View webinar")
                     #webinar-play.hide.z-stack-10.relative
                         - if p.has_key?("video_embed")
                             .group
@@ -76,7 +76,7 @@ ruby:
                                 li
                                     span.label.info.round = data.site.discover[p.discovery_topic.id].title
                         - if p.has_key?("authors")
-                            aside
+                            aside#webinar-authors
                                 .subhead--spaced.faded.headline-6.group--sm Presented by
                                 - p["authors"].each do | author |
                                     p
@@ -87,9 +87,19 @@ ruby:
                             
                     #webinar-bg.absolute.preview-bg.z-stack-0.group.img-multiply.blur-2
                         img.lozad.img-cover src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=840"
-
-
+    section#description.section-article--med
         .row.align-center
+            .columns.small-12.large-6
+                /h4.headline-5
+                    /p = today.in_time_zone("Central Time (US & Canada)").strftime('%A, %B %-d, %Y, %l:%M %p')
+                    = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
+                    span = event_date_full
+                - if p.has_key?("lead")
+                    .lead
+                        = Kramdown::Document.new(p["lead"]).to_html
+                - if p.has_key?("desc")
+                    article.group.content-dynamic
+                        = Kramdown::Document.new(p["desc"]).to_html
             .columns.small-12.large-4
                 - if is_future == true
                     .is-registered.callout.drop.hide
@@ -106,25 +116,15 @@ ruby:
                                     = partial("partials/snippets/person", :locals => { :p => author, :classes => "" })
                 - if p.has_key?("related_form")
                     #report-form.hide
-                        .callout.drop
+                        .callout.drop.group
                             h3.headline-4.text-center.group Register to attend
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
-            .columns.small-12.large-6
-                /h4.headline-5
-                    /p = today.in_time_zone("Central Time (US & Canada)").strftime('%A, %B %-d, %Y, %l:%M %p')
-                    = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
-                    span = event_date_full
-                - if p.has_key?("lead")
-                    .lead
-                        = Kramdown::Document.new(p["lead"]).to_html
-                - if p.has_key?("desc")
-                    article.group.content-dynamic
-                        = Kramdown::Document.new(p["desc"]).to_html
-
-    section#all.section-article--small
-        .row.align-center
-            .columns.small-12.large-6.text-center.group
                 = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
+
+    / section#all.section-article--small
+    /     .row.align-center
+    /         .columns.small-12.large-6.text-center.group
+                
                 / = inline_svg("icon-webinar", class: "icon-size--medium")
                 / h2.headline-5.spaced-out
                 /     a.link--dark href="/webinars" See All Webinars

--- a/source/partials/content/_card-case-study.erb
+++ b/source/partials/content/_card-case-study.erb
@@ -27,8 +27,7 @@
         <% end %>
     </div>
     <div class="card-divider card-section--flush">
-        <a class="button hollow small" href="/customer/<%= cf_customer["slug"] %>" title="<%= cf_customer["company_name"] %> case study">
-            Read the <%= cf_customer["company_name"] %> case study <i class="fa fa-angle-right"></i>
-        </a>
+        <%= partial "partials/snippets/button", :locals => { :label => "Read the #{cf_customer.company_name} Case study", :url => "/customer/#{cf_customer["slug"]}", :button_classes => "button hollow small", :item_id => "customer", :icon => "icon-chevron-right", :icon_align => "right" } %>
     </div>
 </div>
+


### PR DESCRIPTION
Some cosmetic and JS orchestration fixes to the horrible, horrible visual combinations we have spawned in Webinars. Hides bg image and makes surrounding container dark gray when registered. 