### PR TITLE
Perf: fewer fonts to load

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,7 +31,6 @@
     <//cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/js/foundation.min.js>;rel=preload;as=script, \
     <//cdnjs.cloudflare.com/ajax/libs/lozad.js/1.7.0/lozad.min.js>;rel=preload;as=script, \
     </public/js/all.js>;rel=preload;as=script, \
-    </public/fonts/gt-america-light.woff>;rel=preload;as=font;type=font/woff;crossorigin, \
     </public/fonts/gt-america-regular.woff>;rel=preload;as=font;type=font/woff;crossorigin, \
     </public/fonts/gt-america-bold.woff>;rel=preload;as=font;type=font/woff;crossorigin'''
     # <//fast.wistia.com/assets/external/E-v1.js>;rel=preload;as=script, \

--- a/source/assets/scss/modules/fonts.scss
+++ b/source/assets/scss/modules/fonts.scss
@@ -38,19 +38,19 @@ $fam: GT America;
 //     font-style: italic;
 // }
 
-@font-face{
-    src: url('/public/fonts/gt-america-light.woff') format('woff');
-    font-family: $fam;
-    font-display: optional;
-    font-weight: 300;
-}
-@font-face{
-    src: url('/public/fonts/gt-america-lightitalic.woff') format('woff');
-    font-family: $fam;
-    font-display: optional;
-    font-weight: 300;
-    font-style: italic;
-}
+// @font-face{
+//     src: url('/public/fonts/gt-america-light.woff') format('woff');
+//     font-family: $fam;
+//     font-display: optional;
+//     font-weight: 300;
+// }
+// @font-face{
+//     src: url('/public/fonts/gt-america-lightitalic.woff') format('woff');
+//     font-family: $fam;
+//     font-display: optional;
+//     font-weight: 300;
+//     font-style: italic;
+// }
 
 @font-face{
     src: url('/public/fonts/gt-america-regular.woff') format('woff');

--- a/source/assets/scss/settings.scss
+++ b/source/assets/scss/settings.scss
@@ -75,7 +75,7 @@ $font_serif:   "Source Serif Pro", Georgia, serif;
 // Font Weights                    // GT America Mapping; omitting ones that aren't loaded. Can be restored and loaded in fonts.scss.
 $font-weight-xlight:            100; // ultra light
 $font-weight-thin:              200; // thin
-$font-weight-light:             300; // light
+$font-weight-light:             400; // light - testing to see if we can do without this weight
 $font-weight-regular:           400; // regular
 $font-weight-mid:               500; // medium
 $font-weight-sem:               600; // N/A


### PR DESCRIPTION
Pulling out the 300 (light) weight of GT America, to see if we can do without. Already loading lots of other weights and italics too.