### PR TITLE
unmixing mix-blend and blend-background

### DIFF
--- a/source/assets/scss/mixins/functions.scss
+++ b/source/assets/scss/mixins/functions.scss
@@ -433,12 +433,20 @@ $button-transition: transform $timing-default ease, box-shadow $timing-default e
 @mixin blend-multiply {
     @supports (background-blend-mode: multiply) {
         background-blend-mode: multiply;
-        mix-blend-mode: multiply;
     }
 }
 @mixin blend-overlay {
     @supports (background-blend-mode: overlay) {
         background-blend-mode: overlay;
+    }
+}
+@mixin mix-multiply {
+    @supports (mix-blend-mode: multiply) {
+        mix-blend-mode: multiply;
+    }
+}
+@mixin mix-overlay {
+    @supports (mix-blend-mode: overlay) {
         mix-blend-mode: overlay;
     }
 }

--- a/source/assets/scss/modules/images.scss
+++ b/source/assets/scss/modules/images.scss
@@ -87,6 +87,9 @@ figcaption{
 .img-multiply {
     @include blend-multiply;
 }
+.img-mix-multiply {
+    @include mix-multiply;
+}
 .blur {
     &-0 {
         @include blur(0);

--- a/source/press/index.html.erb
+++ b/source/press/index.html.erb
@@ -86,7 +86,7 @@ feed_url: "https://datica.com/press/feed.xml"
                 <% if quote.has_key?("source_logo") %>
                     <p>
                     <a class="blockquote-info" href="<%= quote["url"] %>" title="Read the article on their website">
-                        <img class="logo-size--medium img-multiply" src="<%= quote.source_logo.url %>" alt="<%= quote["source"] %>">
+                        <img class="logo-size--medium img-mix-multiply" src="<%= quote.source_logo.url %>" alt="<%= quote["source"] %>">
                     </a></p>
                 <% end %>
                 <% if quote.has_key?("source") %>


### PR DESCRIPTION
These work differently. Use mix-blend directly on images. It seems. Separated out, you can see on /press and /webinar/[detail] views. #139 