### PR TITLE
Feature/cta video - support for webinar trailers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@
     Referrer-Policy = "same-origin"
     X-Content-Type-Options = "nosniff"
     X-XSS-Protection = "1; mode=block"
+    X-Frame-Options = "SAMEORIGIN"
     Strict-Transport-Security = "max-age=31536000"
     Content-Security-Policy = "frame-ancestors 'self'"
     # Content-Security-Policy-Report-Only = "default-src https: 'unsafe-inline' 'unsafe-eval'"

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -59,11 +59,6 @@ ruby:
                 a href="/webinars" title="See all webinars"
                     = inline_svg("icon-webinar", class: "icon-size--large")
                     h2.headline-5.spaced-out Datica Webinars
-                    h2 = p.trailer_preview.id
-                - if p.has_key("trailer_preview")
-                    
-                    = Kramdown::Document.new(data.site.videos[p.trailer_preview.id].custom_form).to_html
-
         .row.align-center
             .columns.small-12.large-10.group
                 #webinar-container.preview.container-gray-3.relative href="/webinars/#{p["slug"]}" title=("View webinar")
@@ -71,6 +66,11 @@ ruby:
                         - if p.has_key?("video_embed")
                             .group
                                 = Kramdown::Document.new(data.site.videos[p.video_embed.id].custom_form).to_html
+                    // trailer will require multiple condition checks, not worth the trouble yet. 
+                    /- if p.has_key?("trailer_preview")
+                        / h2 = entry.trailer_preview.id
+                        = Kramdown::Document.new(data.site.videos[p.trailer_preview.id].custom_form).to_html
+                    /- else
                     .preview-meta.z-10.relative
                         h1.headline-3.nomargin = p["title"]
                         p.lead = (p.has_key?("subhead") ? p.subhead : nil)

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -50,6 +50,7 @@ ruby:
 
 / section#top.container-gray-2.container-image-fill data-interchange="[#{thumb}, small], [#{thumb}#{image_featured_large}, large]"
 .strip-bright.strip-small
+
 .container-gray-11
     = partial "partials/head/header", :locals => { :style => "dark" }
     section#webinar.section-article--med data-webinar = p._meta.id
@@ -58,6 +59,11 @@ ruby:
                 a href="/webinars" title="See all webinars"
                     = inline_svg("icon-webinar", class: "icon-size--large")
                     h2.headline-5.spaced-out Datica Webinars
+                    h2 = p.trailer_preview.id
+                - if p.has_key("trailer_preview")
+                    
+                    = Kramdown::Document.new(data.site.videos[p.trailer_preview.id].custom_form).to_html
+
         .row.align-center
             .columns.small-12.large-10.group
                 #webinar-container.preview.container-gray-3.relative href="/webinars/#{p["slug"]}" title=("View webinar")

--- a/source/partials/cards/_webinar-poster.slim
+++ b/source/partials/cards/_webinar-poster.slim
@@ -25,8 +25,8 @@ ruby:
     #if is_future == true
     #    cta_label = "Register Today"
     #end
-- if entry.has_key("trailer_preview")
-    h2 = entry.trailer_preview.id
+- if entry.has_key?("trailer_preview")
+    / h2 = entry.trailer_preview.id
     = Kramdown::Document.new(data.site.videos[entry.trailer_preview.id].custom_form).to_html
 - else
     a.preview.container-gray-2.relative href="/webinars/#{entry["slug"]}" title=("View webinar") data-background-image="#{thumb}" data-webinar-id = entry._meta.id

--- a/source/partials/cards/_webinar-poster.slim
+++ b/source/partials/cards/_webinar-poster.slim
@@ -26,8 +26,39 @@ ruby:
     #    cta_label = "Register Today"
     #end
 - if entry.has_key?("trailer_preview")
-    / h2 = entry.trailer_preview.id
-    = Kramdown::Document.new(data.site.videos[entry.trailer_preview.id].custom_form).to_html
+    - the_video = data.site.videos[entry.trailer_preview.id].custom_form
+    /- if defined?(hide_info) && hide_info == true
+    - if defined?(card_style)
+        - case card_style
+        - when "vertical"
+            .card.bg-gray-3
+                = Kramdown::Document.new(the_video).to_html
+                .card-section
+                    h2.headline-4.nomargin = entry["title"]
+                    p = (entry.has_key?("subhead") ? entry.subhead : nil)
+                    = partial "partials/snippets/button", :locals => { :label => "Register today", :url => "/webinars/#{entry.slug}", :button_classes => "button button--light", :icon => "icon-chevron-right", :icon_align => "right" }
+        - when "horizontal" || "wide"
+            .row.align-center
+                .columns.small-12.large-6.group
+                    = Kramdown::Document.new(the_video).to_html
+                .columns.small-12.large-6
+                    .lead
+                        = Kramdown::Document.new(entry["summary"]).to_html
+                    .row.collapse
+                        - if entry.has_key?("authors")
+                            .columns.small-6
+                                .subhead--spaced.faded.headline-5.group--sm Presented by
+                                - entry["authors"].each do | author |
+                                    p
+                                        = partial("partials/snippets/person", :locals => { :p => author })
+                        .columns.small-6
+                            = partial "partials/snippets/button", :locals => { :label => "Register to watch", :url => "/webinars/#{entry.slug}", :button_classes => "button success", :icon => "icon-chevron-right", :icon_align => "right" }
+        - else
+            - puts "⚠️ You specified a 'card_style' without a style matching [vertical|horizontal|wide]. Page: #{current_page.url}"
+    - else ## just show video only
+        = Kramdown::Document.new(the_video).to_html
+
+
 - else
     a.preview.container-gray-2.relative href="/webinars/#{entry["slug"]}" title=("View webinar") data-background-image="#{thumb}" data-webinar-id = entry._meta.id
         .webinar-meta.z-10.relative

--- a/source/partials/cards/_webinar-poster.slim
+++ b/source/partials/cards/_webinar-poster.slim
@@ -25,20 +25,23 @@ ruby:
     #if is_future == true
     #    cta_label = "Register Today"
     #end
-
-a.preview.container-gray-2.relative href="/webinars/#{entry["slug"]}" title=("View webinar") data-background-image="#{thumb}" data-webinar-id = entry._meta.id
-    .webinar-meta.z-10.relative
-        .preview-subhead Datica Webinar
-        .preview-title
-            h2.headline-4.nomargin = entry["title"]
-        div.preview-info(style="margin-bottom: 0.2em;")
-            = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
-            / span = entry['event_date'].strftime('%B %-d, %Y')
-            span = event_date
-        - if entry.has_key?("discovery_topic")
-            div.preview-topic
-                span.label.dark.round = data.site.discover[entry.discovery_topic.id].title
-    .absolute.preview-bg.z-0.group
-        img.lozad.img-cover.img-multiply src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=800"
-    .preview-cta.headline-5.spaced-out.show-for-large.text-right = cta_label
-    = inline_svg("icon-video-play-circle", class: "show-for-large preview-icon icon-size--xlarge svg-color--white")
+- if entry.has_key("trailer_preview")
+    h2 = entry.trailer_preview.id
+    = Kramdown::Document.new(data.site.videos[entry.trailer_preview.id].custom_form).to_html
+- else
+    a.preview.container-gray-2.relative href="/webinars/#{entry["slug"]}" title=("View webinar") data-background-image="#{thumb}" data-webinar-id = entry._meta.id
+        .webinar-meta.z-10.relative
+            .preview-subhead Datica Webinar
+            .preview-title
+                h2.headline-4.nomargin = entry["title"]
+            div.preview-info(style="margin-bottom: 0.2em;")
+                = inline_svg("small/icon-event-note", class: "icon-inline icon-left")
+                / span = entry['event_date'].strftime('%B %-d, %Y')
+                span = event_date
+            - if entry.has_key?("discovery_topic")
+                div.preview-topic
+                    span.label.dark.round = data.site.discover[entry.discovery_topic.id].title
+        .absolute.preview-bg.z-0.group
+            img.lozad.img-cover.img-multiply src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=800"
+        .preview-cta.headline-5.spaced-out.show-for-large.text-right = cta_label
+        = inline_svg("icon-video-play-circle", class: "show-for-large preview-icon icon-size--xlarge svg-color--white")

--- a/source/partials/content/_cta.erb
+++ b/source/partials/content/_cta.erb
@@ -44,6 +44,12 @@ end
         <% if p.has_key?("cta_desc") %><p class=""><%= p["cta_desc"] %></p><% end %>
         <%= p.cta_widget %>
     </aside>
+<% elsif p.has_key?("related_embed") %>
+    <aside class="<%= style_classes %>" id="cta">
+        <% if p.has_key?("custom_form") %>
+            <%= p.custom_form %>
+        <% end %>
+    </aside>
 <% else %>
     <aside class="<%= style_classes %>" id="cta">
         <% if p.has_key?("cta_icon") %>

--- a/source/partials/content/_recent-items.slim
+++ b/source/partials/content/_recent-items.slim
@@ -16,7 +16,7 @@ ruby:
       = partial "partials/cards/featured-blog", :locals => { :post => blog_entry, :style => "light", :size => "small", :show_type => true }
   - sorted_webinars.take(1).each do | id, webinar_entry |
     .column
-      = partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry }
+      = partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :card_style => "vertical" }
   / hiding podcasts for now
   /- sorted_podcasts.take(1).each do | id, podcast_entry |
   /  .column.hide-for-large-only

--- a/source/webinars/index.html.slim
+++ b/source/webinars/index.html.slim
@@ -32,12 +32,15 @@ ruby:
                 .columns.small-12.large-6
                     .lead
                         = Kramdown::Document.new(webinar_entry["summary"]).to_html
-                    - if webinar_entry.has_key?("authors")
-                        aside.group
-                            .subhead--spaced.faded.headline-5.group--sm Presented by
-                            - webinar_entry["authors"].each do | author |
-                                p
-                                    = partial("partials/snippets/person", :locals => { :p => author })
+                    .row.collapse
+                        - if webinar_entry.has_key?("authors")
+                            .columns.small-6
+                                .subhead--spaced.faded.headline-5.group--sm Presented by
+                                - webinar_entry["authors"].each do | author |
+                                    p
+                                        = partial("partials/snippets/person", :locals => { :p => author })
+                        .columns.small-6
+                            = partial "partials/snippets/button", :locals => { :label => "Register to watch", :url => "/webinars/#{webinar_entry.slug}", :button_classes => "button success", :icon => "icon-chevron-right", :icon_align => "right" }
 section.section-article.container-gray-11
     .row.align-center.group
         .columns.small-12.text-center

--- a/source/webinars/index.html.slim
+++ b/source/webinars/index.html.slim
@@ -26,9 +26,10 @@ ruby:
         - sorted_entries.take(1).each do | id, webinar_entry |
             - if webinar_entry.has_key?("event_date")
                 - if today.strftime("%F") >= webinar_entry['event_date'].strftime("%F") ? is_future = false : is_future = true
-            .row.align-center
+            = partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :is_future => is_future, :card_style => "horizontal" }
+            / .row.align-center
                 .columns.small-12.large-6
-                    = partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :is_future => is_future }
+                    
                 .columns.small-12.large-6
                     .lead
                         = Kramdown::Document.new(webinar_entry["summary"]).to_html


### PR DESCRIPTION
Much improved webinar cards, here in `vertical` mode:
![image](https://user-images.githubusercontent.com/887931/55449188-6417ce00-557f-11e9-9220-bd14cc5229bd.png)

And in `horizontal` mode: 
![image](https://user-images.githubusercontent.com/887931/55449212-76920780-557f-11e9-9d09-b64e6b32361b.png)

If no webinar trailer is present, it will fall back to the original layout. 

Other webinar fixes and improvements, component updates as well.