### PR TITLE
Adding support for new, post-form cta_next field.

### DIFF
--- a/source/assets/js/webinar.js
+++ b/source/assets/js/webinar.js
@@ -4,34 +4,22 @@ $("document").ready(function(){
         // $('nav.nav-desktop').attr('data-theme', 'dark');
         $('#webinar').attr('data-theme', 'dark');
         $('#webinar').addClass("bg-gray-2 link--white-parent");
-        $('#webinar-play').removeClass("hide");
-        $('#webinar-authors').addClass("hide");
-        $('.preview-bg').addClass("hide");
-        // $('#webinar-play').addClass("group");
-        $('#preview-register').addClass("hide");
-        // $('#preview-registered').removeClass("hide");
-        // $('#webinar-title').removeClass("hide");
-        $('.is-registered').removeClass("hide");
-        $('#report-form').addClass("hide");
+        $('.show-for-registered').removeClass("hide");
+        $('.hide-for-registered').addClass("hide");
         $.cookie(currPromoCookie, 'true', { expires: 14, path: '/' });
         $('#alertTop').addClass("hide");
-        //$('#webinar-trailer').addClass("hide");
-        console.log('show it');
+        // console.log('show it');
+
     }
     function hideWebinar(){
         // $('nav.nav-desktop').attr('data-theme', 'dark');
         $('#webinar').attr('data-theme', 'light');
-        $('#webinar').removeClass("bg-gray-3 link--white-parent");
-        $('#webinar-play').addClass("hide");
-        $('#webinar-authors').removeClass("hide");
-        $('.preview-bg').removeClass("hide");
-        // $('#preview-register').removeClass("hide");
-        // $('#preview-registered').addClass("hide");
-        // $('#webinar-title').addClass("hide");
-        $('.is-registered').add("hide");
-        $('#report-form').removeClass("hide");
-        console.log('default');
+        $('#webinar').removeClass("bg-gray-2 link--white-parent");
+        $('.show-for-registered').addClass("hide");
+        $('.hide-for-registered').removeClass("hide");
+        // console.log('default');
     }
+
     if($.cookie('webinarReg') == null){
         // console.log('no match. hide thing');
         hideWebinar();
@@ -56,3 +44,4 @@ $("document").ready(function(){
         });
     });
 });
+

--- a/source/assets/scss/mixins/functions.scss
+++ b/source/assets/scss/mixins/functions.scss
@@ -189,9 +189,9 @@ $underline: false !default;
             -ms-flex: $set;
                 flex: $set;
 }
-$button-transition: transform $timing-default ease, box-shadow $timing-default ease-out, background-color $timing-default ease-out, color $timing-default ease-out;
+$button-transition: transform $timing-default ease, box-shadow $timing-default, background-color $timing-default, color $timing-default, border $timing-default;
 @mixin fx-hover-nudge {
-    transition: $button-transition;
+    // transition: $button-transition;
     &:focus,
     &:hover {
         transform: translate3d(3px, 0, 0);

--- a/source/assets/scss/settings.scss
+++ b/source/assets/scss/settings.scss
@@ -521,8 +521,7 @@ $button-palette: $foundation-palette;
 $button-opacity-disabled: 0.25;
 $button-background-hover-lightness: -20%;
 $button-hollow-hover-lightness: -50%;
-$button-transition: transform $timing-default ease, box-shadow $timing-default ease-out, background-color $timing-default ease-out, color $timing-default ease-out;
-
+$button-transition: transform $timing-default ease, box-shadow $timing-default, background-color $timing-default, color $timing-default, border $timing-default;
 // 12. Button Group
 // ----------------
 

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -133,11 +133,13 @@ scss:
                         .callout.drop.group
                             h3.headline-4.text-center.group = (is_future == true ? "Register" : "Register")
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
+                // "next step" actions
                 - if p.has_key?("cta_next")
                     #cta-next.is-registered.hide.text-center-for-small
-                        h4.headline-5.spaced-out.margin-bottom-small Ready for more?
+                        h4.headline-5.spaced-out style="margin-bottom: 0.8em;" Ready for more?
                         = partial("/partials/content/cta", :locals => { :p => p["cta_next"] })
-                = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
+                        = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/contact/", :button_classes => "button", :item_id => "all_webinars", :icon => "icon-chevron-right", :icon_align => "right" }
+                = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow is-registered", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
 
     / section#all.section-article--small
     /     .row.align-center

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -47,7 +47,10 @@ ruby:
         thumb = bg_default
     end
 
-
+scss:
+    .cta {
+        margin-top: 0;
+    }
 / section#top.container-gray-2.container-image-fill data-interchange="[#{thumb}, small], [#{thumb}#{image_featured_large}, large]"
 .strip-bright.strip-small
 .bg-gray-1
@@ -127,6 +130,10 @@ ruby:
                         .callout.drop.group
                             h3.headline-4.text-center.group = (is_future == true ? "Register" : "Register")
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
+                - if p.has_key?("cta_next")
+                    #cta-next.is-registered.hide
+                        h4.headline-5.spaced-out.margin-bottom-small Ready for more?
+                        = partial("/partials/content/cta", :locals => { :p => p["cta_next"] })
                 = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
 
     / section#all.section-article--small

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -136,16 +136,8 @@ scss:
                 // "next step" actions
                 - if p.has_key?("cta_next")
                     #cta-next.show-for-registered.hide.text-center-for-small
-                        h4.headline-5 Read this next:
+                        h4.headline-5 Next:
                         = partial("/partials/content/cta", :locals => { :p => p["cta_next"] })
                         h4.headline-5 Ready for more?
                         = partial "partials/snippets/button", :locals => { :label => "Talk to Sales", :url => "/contact/", :button_classes => "button", :item_id => "all_webinars", :icon => "icon-chevron-right", :icon_align => "right" }
                 = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow hollow-invisible hide-for-registered", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
-
-    / section#all.section-article--small
-    /     .row.align-center
-    /         .columns.small-12.large-6.text-center.group
-                
-                / = inline_svg("icon-webinar", class: "icon-size--medium")
-                / h2.headline-5.spaced-out
-                /     a.link--dark href="/webinars" See All Webinars

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -49,7 +49,7 @@ ruby:
 
 scss:
     .cta {
-        margin-top: 0;
+        margin: 0 0 2rem 0;
         @media screen and (min-width: 40em) {
             max-width: 100%;
         }
@@ -80,7 +80,7 @@ scss:
             .row.align-center.collapse
                 .columns.small-12.large-10.group
                     #webinar-container.preview.container-gray-2.relative href="/webinars/#{p["slug"]}" title=("View webinar")
-                        #webinar-play.hide.z-10.relative
+                        #webinar-play.show-for-registered.hide.z-10.relative
                             - if p.has_key?("video_embed")
                                 .group
                                     = Kramdown::Document.new(data.site.videos[p.video_embed.id].custom_form).to_html
@@ -95,16 +95,16 @@ scss:
                                     li
                                         span.label.info.round = data.site.discover[p.discovery_topic.id].title
                             - if p.has_key?("authors")
-                                aside#webinar-authors
+                                aside#webinar-authors.hide-for-registered
                                     .subhead--spaced.faded.headline-6.group--sm Presented by
                                     - p["authors"].each do | author |
                                         p
                                             = partial("partials/snippets/person", :locals => { :p => author, :classes => "person-light" })
-                        #preview-register.show.show-for-large.absolute(style="bottom: 0; right: 0;")
+                        #preview-register.hide-for-registered.show-for-large.absolute(style="bottom: 0; right: 0;")
                             / .preview-cta.headline-5.spaced-out Register to watch
                             = inline_svg("icon-video-play-circle", class: "preview-icon icon-size--xlarge svg-color--white")
                                 
-                        #webinar-bg.absolute.preview-bg.z-0.group.img-multiply.blur-2
+                        #webinar-bg.hide-for-registered.absolute.preview-bg.z-0.group.img-multiply.blur-2
                             img.lozad.img-cover src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=840"
     section#description.section-article--med
         .row.align-center
@@ -116,7 +116,7 @@ scss:
                         = Kramdown::Document.new(p["desc"]).to_html
             .columns.small-12.medium-6.large-4
                 - if is_future == true
-                    .is-registered.callout.drop.hide
+                    .show-for-registered.callout.drop.hide
                         = inline_svg("small/icon-check-circle", class: "float-right icon-size--large svg-color--green")
                         h3.headline-4 You're Registered!
                         p Join us <strong>#{event_date_full}</strong>
@@ -129,17 +129,18 @@ scss:
                                 p
                                     = partial("partials/snippets/person", :locals => { :p => author, :classes => "" })
                 - if p.has_key?("related_form")
-                    #report-form.hide
+                    #report-form.hide-for-registered.hide
                         .callout.drop.group
                             h3.headline-4.text-center.group = (is_future == true ? "Register" : "Register")
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
                 // "next step" actions
                 - if p.has_key?("cta_next")
-                    #cta-next.is-registered.hide.text-center-for-small
-                        h4.headline-5.spaced-out style="margin-bottom: 0.8em;" Ready for more?
+                    #cta-next.show-for-registered.hide.text-center-for-small
+                        h4.headline-5 Read this next:
                         = partial("/partials/content/cta", :locals => { :p => p["cta_next"] })
-                        = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/contact/", :button_classes => "button", :item_id => "all_webinars", :icon => "icon-chevron-right", :icon_align => "right" }
-                = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow is-registered", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
+                        h4.headline-5 Ready for more?
+                        = partial "partials/snippets/button", :locals => { :label => "Talk to Sales", :url => "/contact/", :button_classes => "button", :item_id => "all_webinars", :icon => "icon-chevron-right", :icon_align => "right" }
+                = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow hollow-invisible hide-for-registered", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }
 
     / section#all.section-article--small
     /     .row.align-center

--- a/source/contentful_templates/webinar.html.slim
+++ b/source/contentful_templates/webinar.html.slim
@@ -50,6 +50,9 @@ ruby:
 scss:
     .cta {
         margin-top: 0;
+        @media screen and (min-width: 40em) {
+            max-width: 100%;
+        }
     }
 / section#top.container-gray-2.container-image-fill data-interchange="[#{thumb}, small], [#{thumb}#{image_featured_large}, large]"
 .strip-bright.strip-small
@@ -105,13 +108,13 @@ scss:
                             img.lozad.img-cover src="#{thumb}?w=250&fm=jpg&q=10" data-src="#{thumb}?w=840"
     section#description.section-article--med
         .row.align-center
-            .columns.small-12.large-6
+            .columns.small-12.medium-6.large-6
                 - if p.has_key?("lead")
                     = Kramdown::Document.new(p["lead"]).to_html
                 - if p.has_key?("desc")
                     article.group
                         = Kramdown::Document.new(p["desc"]).to_html
-            .columns.small-12.large-4
+            .columns.small-12.medium-6.large-4
                 - if is_future == true
                     .is-registered.callout.drop.hide
                         = inline_svg("small/icon-check-circle", class: "float-right icon-size--large svg-color--green")
@@ -131,7 +134,7 @@ scss:
                             h3.headline-4.text-center.group = (is_future == true ? "Register" : "Register")
                             = partial "partials/snippets/form", :locals => { :the_form => data.site.forms[p.related_form.id].custom_form }
                 - if p.has_key?("cta_next")
-                    #cta-next.is-registered.hide
+                    #cta-next.is-registered.hide.text-center-for-small
                         h4.headline-5.spaced-out.margin-bottom-small Ready for more?
                         = partial("/partials/content/cta", :locals => { :p => p["cta_next"] })
                 = partial "partials/snippets/button", :locals => { :label => "See All Datica Webinars", :url => "/webinars/", :button_classes => "button hollow", :item_id => "all_webinars", :icon => "icon-webinar-sm", :icon_align => "left" }


### PR DESCRIPTION
- New `cta_next` field, for choosing a related CTA in the Contentful entry. 
- In the Webinar section (first, which has the necessary existing JS), registering via the form will reveal the CTA `hsvalidatedsubmit` in [webinar.js](https://github.com/daticahealth/seldon-middleman/blob/master/source/assets/js/webinar.js#L44).

![screenshot](https://user-images.githubusercontent.com/887931/57809720-e668e580-771a-11e9-97ee-72e0cea0bf9b.png)
