### PR TITLE
Phase I Content Migration

### DIFF
--- a/source/assets/scss/modules/blog.scss
+++ b/source/assets/scss/modules/blog.scss
@@ -51,6 +51,6 @@ body.blog {
         }
     }
 }
-.card-featured-section .card-header-title {
-    font-size: 1.4rem;
-}
+// .card-featured-section .card-header-title {
+//     font-size: 1.4rem;
+// }

--- a/source/assets/scss/modules/buttons.scss
+++ b/source/assets/scss/modules/buttons.scss
@@ -29,7 +29,7 @@
         @include gradient(to bottom, white 0%, $gray-12 100%);
         // @include shadow-anarchy(inset 0 -1px 2px 0 #B3C8D6);
         // background-color: $gray-12;
-        color: darken($color_product, 20%) !important; // not sure what .container rule is overriding this, it's lower in the OOO
+        color: black !important; // not sure what .container rule is overriding this, it's lower in the OOO
         &:hover, &:active, &:focus {
             color: black !important;
             background-color: white;

--- a/source/assets/scss/modules/icons.scss
+++ b/source/assets/scss/modules/icons.scss
@@ -35,6 +35,11 @@
             height: $thing-l * 1.5;
             // vertical-align: middle;
         }
+        &--xxlarge {
+            width:  $thing-l * 2;
+            height: $thing-l * 2;
+            // vertical-align: middle;
+        }
     }
     // for inline icons, extra space before/after next to text. Default .menu behavior from ZF targets things inside menu elements.
     &-before {

--- a/source/assets/scss/settings.scss
+++ b/source/assets/scss/settings.scss
@@ -218,7 +218,7 @@ $product-colors: (
 $foundation-palette:(
   default:   $color_green,
   primary:   $color_green,
-  secondary: $gray-5,
+  secondary: $color_blue,
   tertiary:  white,
   dark:      $gray-2,
   info:      $gray-7,

--- a/source/assets/scss/views/blog-section.scss
+++ b/source/assets/scss/views/blog-section.scss
@@ -52,6 +52,6 @@ body.blog {
         }
     }
 }
-.card-featured-section .card-header-title {
-    font-size: 1.4rem;
-}
+// .card-featured-section .card-header-title {
+//     font-size: 1.4rem;
+// }

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -61,14 +61,16 @@ current_cta = data.site.cta.to_a.sort_by{ |id, cta| cta['_meta']['updated_at'] }
                     <div class="columns medium-3 large-3 show-for-medium">
                         <% if post.has_key?("featured_image") %>
                             <% 
-                                if post.categories_blog != "Sansoro Health" && post.has_key?("share_image")
-                                    feat_img = post["featured_image"]["url"]
-                                else
+                                # if post.categories_blog != "Sansoro Health"
+                                #     feat_img = post["featured_image"]["url"]
+                                if post.categories_blog == "Sansoro Health" && post.has_key?("share_image")
                                     feat_img = post["share_image"]["url"]
+                                else
+                                    feat_img = post["featured_image"]["url"]
                                 end
                              %>
                             <a href="/blog/<%= post["slug"] %>" title="Read this post">
-                                <img class="lozad thumbnail" src="https://images.ctfassets.net/189dvqdsjh46/10BSgwANXD4R7OKMT1j20G/3ba1fd760173695d4e4fb9ec4199fab9/loader-square.png" data-src="<%= feat_img %>?fit=thumb&fm=jpg&fl=progressive&w=300&h=300" alt="<%= post["featured_image"]["title"] %>">
+                                <img class="lozad thumbnail" src="<%= loader_square %>" data-src="<%= feat_img %>?fit=thumb&fm=jpg&fl=progressive&w=300&h=300" alt="<%= post["featured_image"]["title"] %>">
                             </a>
                         <% end %>
                     </div>
@@ -91,8 +93,15 @@ current_cta = data.site.cta.to_a.sort_by{ |id, cta| cta['_meta']['updated_at'] }
             <div class="column group">
                 <h4 class="headline-5"><a href="/blog/<%= post["slug"] %>" title="Read this post"><%= post["title"] %></a></h4>
                 <% if post.has_key?("featured_image") %>
+                    <% 
+                        if post.categories_blog == "Sansoro Health" && post.has_key?("share_image")
+                            feat_img = post["share_image"]["url"]
+                        else
+                            feat_img = post["featured_image"]["url"]
+                        end
+                     %>
                     <a href="/blog/<%= post["slug"] %>" title="Read this post">
-                        <img class="lozad thumbnail float-left" width="80" src="https://images.ctfassets.net/189dvqdsjh46/10BSgwANXD4R7OKMT1j20G/3ba1fd760173695d4e4fb9ec4199fab9/loader-square.png" data-src="<%= post["featured_image"]["url"] %>?fit=thumb&fm=jpg&fl=progressive&w=160&h=160&q=40" alt="<%= post["featured_image"]["title"] %>">
+                        <img class="lozad thumbnail float-left" width="80" src="<%= loader_square %>" data-src="<%= feat_img %>?fit=thumb&fm=jpg&fl=progressive&w=160&h=160&q=40" alt="<%= post["featured_image"]["title"] %>">
                     </a>
                 <% end %>
                 <div class="pub-date"> <%= post['pub_date'].strftime('%B %-d, %Y') %></div>

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -60,8 +60,15 @@ current_cta = data.site.cta.to_a.sort_by{ |id, cta| cta['_meta']['updated_at'] }
                 <div class="row group row--gutter-small">
                     <div class="columns medium-3 large-3 show-for-medium">
                         <% if post.has_key?("featured_image") %>
+                            <% 
+                                if post.categories_blog != "Sansoro Health" && post.has_key?("share_image")
+                                    feat_img = post["featured_image"]["url"]
+                                else
+                                    feat_img = post["share_image"]["url"]
+                                end
+                             %>
                             <a href="/blog/<%= post["slug"] %>" title="Read this post">
-                                <img class="lozad thumbnail" src="https://images.ctfassets.net/189dvqdsjh46/10BSgwANXD4R7OKMT1j20G/3ba1fd760173695d4e4fb9ec4199fab9/loader-square.png" data-src="<%= post["featured_image"]["url"] %>?fit=thumb&fm=jpg&fl=progressive&w=300&h=300" alt="<%= post["featured_image"]["title"] %>">
+                                <img class="lozad thumbnail" src="https://images.ctfassets.net/189dvqdsjh46/10BSgwANXD4R7OKMT1j20G/3ba1fd760173695d4e4fb9ec4199fab9/loader-square.png" data-src="<%= feat_img %>?fit=thumb&fm=jpg&fl=progressive&w=300&h=300" alt="<%= post["featured_image"]["title"] %>">
                             </a>
                         <% end %>
                     </div>

--- a/source/careers/index.html.slim
+++ b/source/careers/index.html.slim
@@ -36,6 +36,9 @@ scss:
         color: $minty;
       }
     }
+    .button.tertiary {
+      color: black;
+    }
   }
   .text-minty {
     color: $minty;
@@ -122,24 +125,24 @@ scss:
       a.pulse href="#jobs" title="Apply today"
         = inline_svg("icon-angle-down-large", class: "icon-size--large waypoint-icon")
 
-  .strip.strip-small.strip-bright
-  section.section-article--lg.bg-gray-2#jobs
-    .row.align-center.align-middle
-      .columns.small-12.medium-6
-        h3.headline-2.text-bold.text-minty Open Positions
-        p.lead Datica is always looking for talented new team members who are looking for tough challenges. If you are curious about career opportunities with Datica, please email <a href="mailto:nikki.kent@sansorohealth.com">Nikki Kent</a>.
+.strip.strip-small.strip-bright
+section.section-article--lg.bg-gray-2#jobs
+  .row.align-center.align-middle
+    .columns.small-12.medium-6
+      h3.headline-2.text-bold.text-minty Open Positions
+      p.lead Datica is always looking for talented new team members who are looking for tough challenges. If you are curious about career opportunities with Datica, please email <a class="link--white" href="mailto:nikki.kent@sansorohealth.com">Nikki Kent</a>.
 
-        = partial "partials/snippets/button", :locals => { :label => "Check for Open Positions", :url => "https://workforcenow.adp.com/jobs/apply/posting.html?client=SANSORO&amp;ccId=19000101_000001&amp;type=MP&amp;lang=en_US", :button_classes => "button tertiary", :icon => "icon-chevron-right", :icon_align => "right", :expand => false }
+      = partial "partials/snippets/button", :locals => { :label => "Check for Open Positions", :url => "https://workforcenow.adp.com/jobs/apply/posting.html?client=SANSORO&amp;ccId=19000101_000001&amp;type=MP&amp;lang=en_US", :button_classes => "button success", :icon => "icon-chevron-right", :icon_align => "right", :expand => false }
 
-      .columns.small-12.medium-6
+    .columns.small-12.medium-6
 
-        / | <div id="BambooHR" class="group"><script src="//datica.bamboohr.com/js/jobs2.php" type="text/javascript"></script><div id="BambooHR-Footer">Powered by<a href="http://www.bamboohr.com" target="_blank" rel="external"><img src="//www.bamboohr.com/img/footer-logo.png" alt="BambooHR - HR software"/></a></div></div>
-        / p.text-small.text-italic Note: the positions listed show locations because of the way our HR software works. All positions are indeed remote. =)
-  .strip.strip-small.strip-bright
-  section.bg-gray-3
-    .row.full-width.align-middle.grayscale
-      .columns.small-12.large-6.buddies.lozad.container-image--center data-background-image="https://images.ctfassets.net/189dvqdsjh46/4YbBiqOhl4msCGXhNWms2W/0c2e4a7b3c81d67983cbc263f9891c8c/datica_pets_1b.jpg?fm=jpg&fl=progressive&w=1500&q=60"
-        /.headline-5.spaced-out.nomargin Datica
-        h4.headline-1.huge-header.nomargin.text-minty.text-center office
-      .columns.small-12.large-6.buddies.lozad.container-image--center data-background-image="https://images.ctfassets.net/189dvqdsjh46/4LZaErm7Ptk5E0iwcPkn7C/31186719534e2e9713c89a2b1f600ff5/datica_pets_2b.jpg?fm=jpg&fl=progressive&w=1500&q=60"
-        h4.headline-1.huge-header.nomargin.text-minty.text-center friends
+      / | <div id="BambooHR" class="group"><script src="//datica.bamboohr.com/js/jobs2.php" type="text/javascript"></script><div id="BambooHR-Footer">Powered by<a href="http://www.bamboohr.com" target="_blank" rel="external"><img src="//www.bamboohr.com/img/footer-logo.png" alt="BambooHR - HR software"/></a></div></div>
+      / p.text-small.text-italic Note: the positions listed show locations because of the way our HR software works. All positions are indeed remote. =)
+.strip.strip-small.strip-bright
+section.bg-gray-3
+  .row.full-width.align-middle.grayscale
+    .columns.small-12.large-6.buddies.lozad.container-image--center data-background-image="https://images.ctfassets.net/189dvqdsjh46/4YbBiqOhl4msCGXhNWms2W/0c2e4a7b3c81d67983cbc263f9891c8c/datica_pets_1b.jpg?fm=jpg&fl=progressive&w=1500&q=60"
+      /.headline-5.spaced-out.nomargin Datica
+      h4.headline-1.huge-header.nomargin.text-minty.text-center office
+    .columns.small-12.large-6.buddies.lozad.container-image--center data-background-image="https://images.ctfassets.net/189dvqdsjh46/4LZaErm7Ptk5E0iwcPkn7C/31186719534e2e9713c89a2b1f600ff5/datica_pets_2b.jpg?fm=jpg&fl=progressive&w=1500&q=60"
+      h4.headline-1.huge-header.nomargin.text-minty.text-center friends

--- a/source/careers/index.html.slim
+++ b/source/careers/index.html.slim
@@ -128,9 +128,13 @@ scss:
       .columns.small-12.medium-6
         h3.headline-2.text-bold.text-minty Open Positions
         p.lead Datica is always looking for talented new team members who are looking for tough challenges. If you are curious about career opportunities with Datica, please email <a href="mailto:nikki.kent@sansorohealth.com">Nikki Kent</a>.
+
+        = partial "partials/snippets/button", :locals => { :label => "Check for Open Positions", :url => "https://workforcenow.adp.com/jobs/apply/posting.html?client=SANSORO&amp;ccId=19000101_000001&amp;type=MP&amp;lang=en_US", :button_classes => "button tertiary", :icon => "icon-chevron-right", :icon_align => "right", :expand => false }
+
       .columns.small-12.medium-6
-        | <div id="BambooHR" class="group"><script src="//datica.bamboohr.com/js/jobs2.php" type="text/javascript"></script><div id="BambooHR-Footer">Powered by<a href="http://www.bamboohr.com" target="_blank" rel="external"><img src="//www.bamboohr.com/img/footer-logo.png" alt="BambooHR - HR software"/></a></div></div>
-        p.text-small.text-italic Note: the positions listed show locations because of the way our HR software works. All positions are indeed remote. =)
+
+        / | <div id="BambooHR" class="group"><script src="//datica.bamboohr.com/js/jobs2.php" type="text/javascript"></script><div id="BambooHR-Footer">Powered by<a href="http://www.bamboohr.com" target="_blank" rel="external"><img src="//www.bamboohr.com/img/footer-logo.png" alt="BambooHR - HR software"/></a></div></div>
+        / p.text-small.text-italic Note: the positions listed show locations because of the way our HR software works. All positions are indeed remote. =)
   .strip.strip-small.strip-bright
   section.bg-gray-3
     .row.full-width.align-middle.grayscale

--- a/source/contentful_templates/podcast.html.erb
+++ b/source/contentful_templates/podcast.html.erb
@@ -151,14 +151,6 @@ filtered_webinars = data.site.webinars.to_a.select{ |id, webinars| webinars.has_
         </div>
         <aside class="columns small-12 large-4 section--sidebar">
             <div class="group">
-                <% unless p.has_key?("category_brand") && p.category_brand == true %>
-                    <p><strong>Subscribe</strong> to the <em>Healthcare Innovator's Podcast</em> in your favorite app.</p>
-                    <%= partial "innovation/partials/subscribe" %>
-                <% else %>
-                    <p>Subscribe to the <a href="https://fourbyfourhealth.podbean.com/" title="Subscribe">4x4 Health Podcast on Podbean</a>.</p>
-                <% end %>
-            </div>
-            <div class="group">
                 <% filtered_webinars.take(1).each do | id, webinar_entry | %>
                 <%= partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :card_style => "vertical" } %>
                 <% end %>

--- a/source/ehr-integration/index.html.slim
+++ b/source/ehr-integration/index.html.slim
@@ -42,7 +42,7 @@ section#top.show-for-large.section-article.pad-no-bottom.bg-gray-12.container-im
         .bg-white.pad--lg
           h2.headline-3.text-bold Activate your digital health product with data from any EHR
           p.lead You've created an amazing healthcare application, now it's time to grow by exchanging data with more EHRs. Datica enables EHR integrations at scale.
-          = partial "partials/snippets/button", :locals => { :label => "Start your integration project", :url => "/compliant-managed-integration#cta", :button_classes => "button nomargin secondary", :data_track_group => "integration", :item_id => "get-integration-desktop", :icon => "icon-chevron-right", :icon_align => "right" }
+          = partial "partials/snippets/button", :locals => { :label => "Start your integration project", :url => "/compliant-managed-integration#cta", :button_classes => "button nomargin dark", :data_track_group => "integration", :item_id => "get-integration-desktop", :icon => "icon-chevron-right", :icon_align => "right" }
 .strip.strip-cmi
 
 / section#top.section-article.bg-gray-11.container-image-fill.lozad data-background-image="?fit=crop&w=1600&h=800"

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -122,6 +122,9 @@ section.section-article.bg-gray-12.drop-inset--v#education
         h4.headline-4.margin-bottom-small
           a href=item.url title=item.title data-track-category="education" data-track-id="resources_#{item.slug}" = item.title
         p = item.desc
+
+/= partial "/partials/section-promos/podcast"
+
 section.section-article.bg-white#recent
   = partial "partials/content/recent-items"
 

--- a/source/innovation/index.html.erb
+++ b/source/innovation/index.html.erb
@@ -62,64 +62,8 @@ customCSS: "innovation"
 
     <%= partial "/partials/section-promos/leadership-gallery" %>
 
-    <% sorted_podcasts = data.site.podcast.to_a.sort_by{ |id, podcast| podcast['pub_date'] }.reverse! %>
-    <section data-magellan-target="discoverInnovation" id="discoverInnovation" class="lozad discover--podcast section-article container-color--dark-alt container-image--middle" data-background-image="https://images.ctfassets.net/189dvqdsjh46/19d5iulqaYg8ACWcYQ6Im6/3f883ec8f77add5b22a497e3b3d63e6d/art-sound-bars-purple.svg">
-        <div class="row align-center collapse">
-            <div class="columns small-12 large-10">
-                <h3 class="innovation--section-header">Healthcare Innovators <span class="innovation--category">Podcast</span></h3>
-                <% sorted_podcasts.take(1).each do | id, podcast | %>
-                    <div class="row innovation--podcast-entry">
-                        <div class="columns small-12 medium-3">
-                            <% if podcast.has_key?("guest") %>
-                                <% if podcast["guest"].has_key?("fullname") %>
-                                    <div class="person-vertical show-for-medium">
-                                        <a class="" href="/innovation/<%= podcast["slug"] %>" title="Listen to this episode now">
-                                            <img src="https://images.ctfassets.net/189dvqdsjh46/7dsvS1pbuo2etN908phqGD/4acf3ebbf566f0f31cf74882f6faa3e8/loader-disc.svg" data-src="<%= podcast["guest"]["profile_pic"]["url"] %>?fit=thumb&w=400&h=400&f=face&q=45" class="lozad avatar circle group--sm" alt="<%= podcast["guest"]["fullname"] %>">
-                                        </a>
-                                        <div class="text-center">
-                                            <div class="person-name"><%= podcast["guest"]["fullname"] %></div>
-                                            <div class="person-title"><%= podcast["guest"]["role"] %></div>
-                                        </div>
-                                    </div>
-                                <% end %>
-                            <% end %>
-                        </div>
-                        <div class="columns small-12 medium-9">
-                            <h3 class="headline-5">
-                                <a class="link--bright" href="/innovation/<%= podcast["slug"] %>" title="Listen to this episode now"><%= podcast["title"] %></a>
-                            </h3>
-                            <div class="person hide-for-medium">
-                                <%= partial("partials/snippets/person", :locals => { :p => podcast["guest"] }) %>
-                            </div>
-                            <p>
-                                <% if podcast.has_key?("pub_date") %>
-                                    <span class="pub-date"><%= podcast['pub_date'].strftime('%B %-d, %Y') %></span>
-                                <% end %>
-                                <% if podcast.has_key?("tags") %>
-                                    <% podcast["tags"].each do |tag| %>
-                                        <% if tag.has_key?("tag_full") %>
-                                            <span class="label info round faded"><%= tag["tag_full"] %></span>
-                                        <% end %>
-                                    <% end %>
-                                <% end %>
-                            </p>
-                            <% if podcast.has_key?("soundcloud_embed") %>
-                                <div class="media-object">
-                                    <%= podcast['soundcloud_embed'] %>
-                                </div>
-                            <% end %>
-                            <% if podcast.has_key?("summary") %>
-                                <div class="innovation--podcast-entry__summary">
-                                    <%= Kramdown::Document.new(podcast["summary"]).to_html %>
-                                    <a class="button hollow hollow-inverted" href="/innovation/<%= podcast["slug"] %>" title="Listen now">Listen now <i class="fa fa-angle-right" aria-hidden="true"></i></a>
-                                </div>
-                            <% end %>
-                        </div>
-                    </div>
-                <% end %>
-                <p class="text-center"><a class="link--bright" href="/podcast/">See More Podcasts <i class="fa fa-angle-right" aria-hidden="true"></i></a></p>
-            </div>
-        </div>
-    </section>
+    <div data-magellan-target="discoverInnovation" id="discoverInnovation">
+        <%= partial "/partials/section-promos/podcast" %>
+    </div>
 </div>
 <%= partial "/partials/section-promos/dhsf-video", :locals => { :align => "left" } %>

--- a/source/partials/cards/_featured-blog.erb
+++ b/source/partials/cards/_featured-blog.erb
@@ -70,7 +70,7 @@ card_summary = truncate_words(strip_tags(entry_summary), :length => 45)
     </a><% end %>
 
     <% if url_segment == "innovation" %><a class="container-image-fill card-header-image card-header-image--compact container-gray-3 lozad" href="<%= related_post_path %>" title="Read '<%= post["title"] %>/'" data-background-image="/public/img/art/art-sound-bars-purple.svg">
-        <span class="card-header-subhead">Healthcare Innovators Podcast</span>
+        <span class="card-header-subhead">Datica Podcasts</span>
         <h2 class="card-header-title headline-5 ribbon--gray-1"><%= post["title"] %></h2>
         <%= inline_svg("icon-video-play-circle", class: "icon-size--xlarge card-header-icon svg-color--white") %>
     </a><% end %>

--- a/source/partials/content/_recent-items.slim
+++ b/source/partials/content/_recent-items.slim
@@ -9,7 +9,7 @@ ruby:
   h3.headline-3 <strong>Recently</strong> at Datica
 .row.full-width.align-center.align-middle.small-up-1.medium-up-2.large-up-3.xlarge-up-4
   - sorted_guides.take(1).each do | id, guide_entry |
-    .column.hide-for-large-only
+    .column.hide-for-large.hide-for-xlarge
       = partial "partials/cards/card-report", :locals => { :post => guide_entry, :style => "dark", :size => "small" }
   - sorted_posts.take(1).each do | id, blog_entry |
     .column
@@ -17,10 +17,9 @@ ruby:
   - sorted_webinars.take(1).each do | id, webinar_entry |
     .column
       = partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :card_style => "vertical" }
-  / hiding podcasts for now
-  /- sorted_podcasts.take(1).each do | id, podcast_entry |
-  /  .column.hide-for-large-only
-  /    = partial "partials/cards/featured-blog", :locals => { :post => podcast_entry, :style => "light", :size => "small", :show_type => true }
+  - sorted_podcasts.take(1).each do | id, podcast_entry |
+    .column.hide-for-large-only
+      = partial "partials/cards/featured-blog", :locals => { :post => podcast_entry, :style => "light", :size => "small", :show_type => true }
   - sorted_reports.take(1).each do | id, report_entry |
     .column
       = partial "partials/cards/card-report", :locals => { :post => report_entry, :style => "dark", :size => "small" }

--- a/source/partials/section-promos/_podcast.html.erb
+++ b/source/partials/section-promos/_podcast.html.erb
@@ -1,0 +1,65 @@
+    <% sorted_podcasts = data.site.podcast.to_a.sort_by{ |id, podcast| podcast['pub_date'] }.reverse! %>
+
+    <section class="lozad discover--podcast section-article container-color--dark-alt container-image--middle" data-background-image="https://images.ctfassets.net/189dvqdsjh46/19d5iulqaYg8ACWcYQ6Im6/3f883ec8f77add5b22a497e3b3d63e6d/art-sound-bars-purple.svg">
+        <div class="row align-center group">
+            <div class="columns">
+                <h3 class="headline-2 group text-center">Datica <span class="text-bold">Podcasts</span></h3>
+            </div>
+        </div>
+        <div class="row align-center collapse">
+            <div class="columns small-12 large-10">
+                
+                <% sorted_podcasts.take(1).each do | id, podcast | %>
+                    <div class="row innovation--podcast-entry">
+                        <div class="columns small-12 medium-3">
+                            <% if podcast.has_key?("guest") %>
+                                <% if podcast["guest"].has_key?("fullname") %>
+                                    <div class="person-vertical show-for-medium">
+                                        <a class="" href="/innovation/<%= podcast["slug"] %>" title="Listen to this episode now">
+                                            <img src="https://images.ctfassets.net/189dvqdsjh46/7dsvS1pbuo2etN908phqGD/4acf3ebbf566f0f31cf74882f6faa3e8/loader-disc.svg" data-src="<%= podcast["guest"]["profile_pic"]["url"] %>?fit=thumb&w=400&h=400&f=face&q=45" class="lozad avatar circle group--sm" alt="<%= podcast["guest"]["fullname"] %>">
+                                        </a>
+                                        <div class="text-center">
+                                            <div class="text-bold"><%= podcast["guest"]["fullname"] %></div>
+                                            <div class="person-title"><%= podcast["guest"]["role"] %></div>
+                                        </div>
+                                    </div>
+                                <% end %>
+                            <% end %>
+                        </div>
+                        <div class="columns small-12 medium-9">
+                            <h4 class="headline-5">
+                                <a class="link--bright" href="/innovation/<%= podcast["slug"] %>" title="Listen to this episode now"><%= podcast["title"] %></a>
+                            </h4>
+                            <div class="person hide-for-medium">
+                                <%= partial("partials/snippets/person", :locals => { :p => podcast["guest"] }) %>
+                            </div>
+                            <p>
+                                <% if podcast.has_key?("pub_date") %>
+                                    <span class="pub-date"><%= podcast['pub_date'].strftime('%B %-d, %Y') %></span>
+                                <% end %>
+                                <% if podcast.has_key?("tags") %>
+                                    <% podcast["tags"].each do |tag| %>
+                                        <% if tag.has_key?("tag_full") %>
+                                            <span class="label info round faded"><%= tag["tag_full"] %></span>
+                                        <% end %>
+                                    <% end %>
+                                <% end %>
+                            </p>
+                            <% if podcast.has_key?("soundcloud_embed") %>
+                                <div class="media-object nomargin">
+                                    <%= podcast['soundcloud_embed'] %>
+                                </div>
+                            <% end %>
+                            <% if podcast.has_key?("summary") %>
+                                <div class="innovation--podcast-entry__summary">
+                                    <%= Kramdown::Document.new(podcast["summary"]).to_html %>
+                                    <a class="button hollow hollow-inverted" href="/innovation/<%= podcast["slug"] %>" title="Listen now">Listen now <i class="fa fa-angle-right" aria-hidden="true"></i></a>
+                                </div>
+                            <% end %>
+                        </div>
+                    </div>
+                <% end %>
+                <!-- <p class="text-center"><a class="link--bright" href="/podcast/">See More Podcasts <i class="fa fa-angle-right" aria-hidden="true"></i></a></p> -->
+            </div>
+        </div>
+    </section>

--- a/source/partials/snippets/_podcast-summary.erb
+++ b/source/partials/snippets/_podcast-summary.erb
@@ -1,5 +1,13 @@
+<% 
+art_4x4 = 'https://images.ctfassets.net/189dvqdsjh46/OCqNIzzZeoJWSTjECEZFp/8c84b526bba5c19e748db5d51568d876/podcast-4x4-small.jpg'
+art_hip = 'https://images.ctfassets.net/189dvqdsjh46/62u8jLbOQyiVfPMZFT8MvY/7a5cc175ff0f418c4ee94f0b26430a2a/podcast-hip-small.jpg'
+unless podcast.has_key?("category_brand") && podcast.category_brand == true
+    brand = ' <img class="float-right icon-size--medium lozad" src=' + loader_square_svg + ' data-src="' + art_hip + '?w=80" alt="Healthcare Innovators Podcast" width="64" />' #' <span class="label secondary">Healthcare Innovators</span> '
+else
+    brand = ' <img class="float-right icon-size--medium lozad" src=' + loader_square_svg + ' data-src="' + art_4x4 + '?w=80" alt="4x4 Health Podcast" width="64" />' #' <span class="label success">4x4 Health</span> '
+end
+%>
 <% if locals.key?(:hideSummary) && hideSummary == true %> <!-- compact view -->
-
     <span class="blog-date color-talk-alt">
         <% if locals.key?(:itemLabel) %>
             <%= itemLabel %>
@@ -20,6 +28,7 @@
                     <%= podcast['pub_date'].strftime('%B %-d, %Y') %>
                 <% end %>
             </span>
+            <%#= brand %>
             <h4 class="headline-5"><a class="text-bold" href="/innovation/<%= podcast["slug"] %>/"><%= podcast["title"] %></a></h4>
             <% if podcast.has_key?("guest") && podcast["guest"].has_key?("fullname") %>
                 <a class="" href="/innovation/<%= podcast["slug"] %>" title="Listen to this episode now">

--- a/source/partials/snippets/_to-top.erb
+++ b/source/partials/snippets/_to-top.erb
@@ -1,1 +1,1 @@
-<a href="#top" class="">Back to top <i class="fa fa-angle-up" aria-hidden="true"></i></a>
+<a href="#top" class="">Back to top</a>

--- a/source/podcast/index.html.erb
+++ b/source/podcast/index.html.erb
@@ -1,28 +1,55 @@
 ---
-title: "Healthcare Innovators Podcast from Datica"
+title: "Datica Podcasts | Home of the 4x4 Health and Healthcare Innovators Podcasts"
 summary: "How does healthcare innovate? Datica explores this topic in a new series of interviews with several of the industry's top thinkers and doers. Follow along with us as we uncover insights to catalyzing change in healthcare."
 author: "Datica, Inc."
 tags: "HIPAA, HL7, FHIR, interoperability, EHR, Kubernetes"
-date: "January 1, 2017"
 share_image: "https://images.ctfassets.net/189dvqdsjh46/at0B5zJqmIk8EAoKqgQww/bc7605c8d6702518cedcedf7cf0de3bb/podcast-art-share-2018.png"
-header: "The Healthcare Innovators Podcast"
+header: "Datica Podcasts"
 subheader: "How does healthcare innovate? Datica explores this topic in a new series of interviews with several of the industry's top thinkers and doers. Follow along with us as we uncover insights to catalyzing change in healthcare."
 layout: basic
-feed_url: "https://datica.com/podcast/feed.xml"
+feed_url: "https://fourbyfourhealth.podbean.com/feed.xml"
 ---
 <% 
+    today = DateTime.now
+    current_page.data.date = today.strftime('%B %-d, %Y')
     sorted_webinars = data.site.webinars.to_a.sort_by{ |id, webinars| webinars['event_date'] }.reverse!
     sorted_reports = data.site.reports.to_a.sort_by{ |id, report| report['pub_date'] }.reverse!
     sorted_podcasts = data.site.podcast.to_a.sort_by{ |id, podcast| podcast['pub_date'] }.reverse!
     sorted_guides = data.site.guides.to_a.sort_by{ |id, guides| guides['_meta']['created_at'] }.reverse!
+    art_4x4 = 'https://images.ctfassets.net/189dvqdsjh46/OCqNIzzZeoJWSTjECEZFp/8c84b526bba5c19e748db5d51568d876/podcast-4x4-small.jpg'
+    art_hip = 'https://images.ctfassets.net/189dvqdsjh46/62u8jLbOQyiVfPMZFT8MvY/7a5cc175ff0f418c4ee94f0b26430a2a/podcast-hip-small.jpg'
 %>
-<div class="container-color--dark-alt container-image--bottom" data-interchange="[https://images.ctfassets.net/189dvqdsjh46/5OUXo4nQ6kaqAsqE8McqIu/fcd84d36da7ad0c4b91ecb9cadb7ce87/art-sound-bars-bg.svg, small]">
+<div class="container-color--dark-alt container-image--middle lozad" data-background-image="/public/img/art/art-sound-bars-purple.svg">
     <%= partial "partials/head/header", :locals => { :style => "light" } %>
     <section class="section-article">
-        <div class="row">
-            <div class="columns small-12 medium-8 featured-post">
-                <h1 class="headline-3 headline--inverted"><%= current_page.data.header %></h1>
-                <p class="lead"><%= current_page.data.subheader %></p>
+        <div class="row align-middle align-center">
+            <div class="columns small-12 medium-6 large-4">
+                <h1 class="headline-2 text-white text-bold text-right">Datica Podcasts</h1>
+            </div>
+            <div class="columns small-12 medium-6 large-8">
+                <div class="media-object group">
+                    <div class="media-object-section">
+                        <a href="#podcast-4x4" title="view podcast">
+                         <img class="float-right icon-size--xxlarge lozad" src="<%= loader_square_svg %>" data-src="<%= art_4x4 %>?w=150" alt="4x4 Health Podcast" width="64" />
+                         </a>
+                    </div>
+                    <div class="media-object-section">
+                        <h4 class="headline-4">4×4 Health Podcast</h4>
+                        <p>The 4×4 Health defines the conversation around Health IT. Data is revolutionizing healthcare and we are tracking this revolution in real-time with the actual disrupters of health informatics.</p>
+                    </div>
+                </div>
+                <div class="media-object">
+                    <div class="media-object-section">
+                        <a href="#podcast-hip" title="view podcast">
+                         <img class="float-right icon-size--xxlarge lozad" src="<%= loader_square_svg %>" data-src="<%= art_hip %>?w=150" alt="Healthcare Innovators Podcast" width="64" /
+                         >
+                         </a>
+                    </div>
+                    <div class="media-object-section">
+                        <h4 class="headline-4">The Healthcare Innovators Podcast</h4>
+                        <p>Datica explores the secrets of innovators in healthcare in a new series of interviews with several of the industry's top thinkers and doers.</p>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -62,10 +89,6 @@ feed_url: "https://datica.com/podcast/feed.xml"
             </div>
         </div>
         <aside class="columns small-12 large-4 section--sidebar">
-            <div class="group text-center">
-                <p><%= inline_svg("subscribe-badge", class: "icon-size--xlarge") %></p>
-                <p><%= partial "innovation/partials/subscribe" %></p>
-            </div>
             <%  sorted_webinars.take(1).each do | id, webinar_entry |%>
               <%= partial "partials/cards/webinar-poster", :locals => { :entry => webinar_entry, :card_style => "vertical" } %>
             <% end %>
@@ -74,14 +97,54 @@ feed_url: "https://datica.com/podcast/feed.xml"
     </div>
 </section>
 <section id="podcasts" class="section-article container-color--gray-light">
-    <div class="row">
-        <div class="columns small-12 large-8">
-            <% sorted_podcasts[1...-1].each do | id, podcast | %>
-                <%= partial("partials/snippets/podcast-summary", :locals => { :podcast => podcast, :hideSummary => false }) %>
+     <div class="row">
+        <div id="podcast-4x4" class="columns small-12 large-8">
+            <div class="card drop group--2x">
+                <div class="card-section">
+                    <div class="media-object">
+                        <div class="media-object-section">
+                             <img class="lozad" src="<%= loader_square_svg %>" data-src="<%= art_4x4 %>?w=320" alt="4x4 Health Podcast" width="160" />
+                        </div>
+                        <div class="media-object-section">
+                            <h4 class="headline-4">4×4 Health Podcast</h4>
+                            <p>The 4×4 Health defines the conversation around Health IT. Data is revolutionizing healthcare and we are tracking this revolution in real-time with the actual disrupters of health informatics.</p>
+                            <p>Subscribe to the <a href="https://fourbyfourhealth.podbean.com/" title="Subscribe">4x4 Health Podcast on Podbean</a>.</p>
 
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <% sorted_podcasts[1...-1].each do | id, podcast | %>
+                <% if podcast.has_key?("category_brand") && podcast.category_brand == true %>
+                    <%= partial("partials/snippets/podcast-summary", :locals => { :podcast => podcast, :hideSummary => false }) %>
+                <% end %>
             <% end %>
-            <hr>
-            <%= partial "partials/snippets/to-top" %>
+            <%= partial "partials/snippets/button", :locals => { :label => "Back to Top", :url => "#top", :button_classes => "button hollow hollow-invisible group--2x", :icon => "icon-chevron-up", :icon_align => "right", :expand => false } %>
+            
+            <div id="podcast-hip" class="card drop group--2x">
+                <div class="card-section">
+                    <div class="media-object">
+                        <div class="media-object-section">
+                             <img class="lozad" src="<%= loader_square_svg %>" data-src="<%= art_hip %>?w=320" alt="Healthcare Innovators Podcast" width="160" />
+                        </div>
+                        <div class="media-object-section">
+                            <h4 class="headline-4">The Healthcare Innovators Podcast</h4>
+                            <p>Datica explores the secrets of innovators in healthcare in a new series of interviews with several of the industry's top thinkers and doers.</p>
+                            <p><strong>Subscribe</strong> to the <em>Healthcare Innovator's Podcast</em> in your favorite app.</p>
+                            <%= partial "innovation/partials/subscribe" %>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <% sorted_podcasts[1...-1].each do | id, podcast | %>
+                <% unless podcast.has_key?("category_brand") && podcast.category_brand == true %>
+                    <%= partial("partials/snippets/podcast-summary", :locals => { :podcast => podcast, :hideSummary => false }) %>
+                <% end %>
+            <% end %>
+
+            <%= partial "partials/snippets/button", :locals => { :label => "Back to Top", :url => "#top", :button_classes => "button hollow hollow-invisible group--2x", :icon => "icon-chevron-up", :icon_align => "right", :expand => false } %>
         </div>
         <aside class="columns small-12 large-4 section--sidebar" data-sticky-container>
             <div class="sticky" data-sticky data-options="anchor: podcasts; stickyOn: large;">


### PR DESCRIPTION
Lots of new features to detect and handle legacy (Sansoro Health) content that's being folded into the Contentful mix. 

- Podcast enhancements
- Conditionals on blog posts without custom featured images (or all the same ones). Falls back to social share images. This flag will need to be removed if new images are added to those entries (`category: Sansoro Health`)
- Careers page points to new listing page