### PR TITLE
Changing careers mail link

### DIFF
--- a/source/careers/index.html.slim
+++ b/source/careers/index.html.slim
@@ -116,7 +116,7 @@ section.section-article--lg.bg-gray-2#jobs
   .row.align-center.align-middle
     .columns.small-12.medium-6
       h3.headline-2.text-bold.text-minty Open Positions
-      p.lead Datica is always looking for talented new team members who are looking for tough challenges. If you are curious about career opportunities with Datica, please email <a class="link--white" href="mailto:nikki.kent@sansorohealth.com">Nikki Kent</a>.
+      p.lead Datica is always looking for talented new team members who are looking for tough challenges. If you are curious about career opportunities with Datica, please email <a class="link--white" href="mailto:rachel.mcnamara@datica.com">Rachel McNamara</a>.
 
       = partial "partials/snippets/button", :locals => { :label => "Check for Open Positions", :url => "https://workforcenow.adp.com/jobs/apply/posting.html?client=SANSORO&amp;ccId=19000101_000001&amp;type=MP&amp;lang=en_US", :button_classes => "button success", :icon => "icon-chevron-right", :icon_align => "right", :expand => false }
 


### PR DESCRIPTION
Removing Nikki Kent as the main contact on the careers page to Rachel McNamara.